### PR TITLE
FAC-234 Add validation for Assessment Attribute Level relation

### DIFF
--- a/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/adapter/out/calculation/LoadAdviceCalculationInfoAdapter.java
+++ b/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/adapter/out/calculation/LoadAdviceCalculationInfoAdapter.java
@@ -6,7 +6,7 @@ import org.flickit.assessment.advice.application.domain.Option;
 import org.flickit.assessment.advice.application.domain.Plan;
 import org.flickit.assessment.advice.application.domain.Question;
 import org.flickit.assessment.advice.application.port.in.CreateAdviceUseCase.AttributeLevelTarget;
-import org.flickit.assessment.advice.application.port.out.LoadAdviceCalculationInfoPort;
+import org.flickit.assessment.advice.application.port.out.calculation.LoadAdviceCalculationInfoPort;
 import org.flickit.assessment.common.exception.ResourceNotFoundException;
 import org.flickit.assessment.data.jpa.core.assessmentresult.AssessmentResultJpaRepository;
 import org.flickit.assessment.data.jpa.core.attributematurityscore.AttributeMaturityScoreJpaEntity;

--- a/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/adapter/out/persistence/assessment/AssessmentAttrLevelExistenceJpaAdapter.java
+++ b/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/adapter/out/persistence/assessment/AssessmentAttrLevelExistenceJpaAdapter.java
@@ -1,0 +1,19 @@
+package org.flickit.assessment.advice.adapter.out.persistence.assessment;
+
+import lombok.RequiredArgsConstructor;
+import org.flickit.assessment.advice.application.port.out.assessment.AssessmentAttrLevelExistencePort;
+import org.flickit.assessment.data.jpa.core.assessment.AssessmentJpaRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AssessmentAttrLevelExistenceJpaAdapter implements AssessmentAttrLevelExistencePort {
+
+    private final AssessmentJpaRepository repository;
+    @Override
+    public boolean exists(UUID assessmentId, Long attributeId, Long maturityLevelId) {
+        return repository.existsByAttributeIdAndMaturityLevelId(assessmentId, attributeId, maturityLevelId);
+    }
+}

--- a/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/application/port/out/assessment/AssessmentAttrLevelExistencePort.java
+++ b/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/application/port/out/assessment/AssessmentAttrLevelExistencePort.java
@@ -1,0 +1,8 @@
+package org.flickit.assessment.advice.application.port.out.assessment;
+
+import java.util.UUID;
+
+public interface AssessmentAttrLevelExistencePort {
+
+    boolean exists(UUID assessmentId, Long attributeId, Long maturityLevelId);
+}

--- a/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/application/port/out/calculation/LoadAdviceCalculationInfoPort.java
+++ b/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/application/port/out/calculation/LoadAdviceCalculationInfoPort.java
@@ -1,4 +1,4 @@
-package org.flickit.assessment.advice.application.port.out;
+package org.flickit.assessment.advice.application.port.out.calculation;
 
 import org.flickit.assessment.advice.application.domain.Plan;
 import org.flickit.assessment.advice.application.port.in.CreateAdviceUseCase.AttributeLevelTarget;

--- a/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/common/ErrorMessageKey.java
+++ b/flickit-advice-engine/src/main/java/org/flickit/assessment/advice/common/ErrorMessageKey.java
@@ -13,4 +13,5 @@ public class ErrorMessageKey {
     public static final String CREATE_ADVICE_ASSESSMENT_NOT_FOUND = "create-advice.assessment.notFound";
     public static final String CREATE_ADVICE_ASSESSMENT_RESULT_NOT_VALID = "create-advice.assessmentResult.notValid";
     public static final String CREATE_ADVICE_FINDING_BEST_SOLUTION_EXCEPTION = "create-advice.finding-best-solution.execution";
+    public static final String CREATE_ADVICE_ASSESSMENT_ATTRIBUTE_LEVEL_NOT_FOUND = "create-advice.assessmentAttributeLevel.notFound";
 }

--- a/flickit-assessment-common/src/main/resources/i18n/advice/messages_en.properties
+++ b/flickit-assessment-common/src/main/resources/i18n/advice/messages_en.properties
@@ -5,5 +5,4 @@ create-advice.assessmentResult.notFound=no assessmentResult found by this 'asses
 create-advice.assessment.notFound=no assessment found by this 'assessmentId'
 create-advice.assessmentResult.notValid=assessmentResult is not valid. Recalculation is needed
 create-advice.finding-best-solution.execution=an error occurred while trying to compute advice
-
-load-advice-calc.assessmentResult.notFound= no assessmentResult found by this 'assessmentId'
+create-advice.assessmentAttributeLevel.notFound=Given attribute level target does not belong to this assessment

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/core/assessment/AssessmentJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/core/assessment/AssessmentJpaRepository.java
@@ -69,6 +69,28 @@ public interface AssessmentJpaRepository extends JpaRepository<AssessmentJpaEnti
         """)
     Optional<UUID> checkUserAccess(@Param(value = "assessmentId") UUID assessmentId,
                                    @Param(value = "userId") UUID userId);
+
+    @Query("""
+            SELECT CASE WHEN EXISTS(
+                SELECT 1
+                FROM AssessmentJpaEntity asm
+                JOIN AssessmentKitJpaEntity kit
+                ON asm.assessmentKitId = kit.id
+                JOIN AttributeJpaEntity atr
+                ON atr.kitId = kit.id
+                JOIN MaturityLevelJpaEntity level
+                ON level.kitId = kit.id
+                WHERE asm.id = :assessmentId
+                AND atr.id = :attributeId
+                AND level.id = :maturityLevelId
+            )
+            THEN true
+            ELSE false
+            END
+    """)
+    boolean existsByAttributeIdAndMaturityLevelId(UUID assessmentId,
+                                                  Long attributeId,
+                                                  Long maturityLevelId);
 }
 
 


### PR DESCRIPTION
Code to validate the relation between Assessment, Attribute and maturity Level has been added to ensure existence before proceeding with advice creation. This is implemented through new validation methods in CreateAdviceService. A new test case for this scenario has been added in CreateAdviceServiceTest. Additionally, the code restructure includes moving LoadAdviceCalculationInfoPort to a new package.