### PR TITLE
FAC-238 Add EvidenceType enum

### DIFF
--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/domain/EvidenceType.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/domain/EvidenceType.java
@@ -1,0 +1,27 @@
+package org.flickit.assessment.core.application.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum EvidenceType {
+
+    POSITIVE,
+    NEGATIVE;
+
+    public int getId() { return ordinal() + 1; }
+
+    public String getTitle() { return name().toLowerCase();}
+
+    public static EvidenceType valueOfById(int id) {
+        return Stream.of(EvidenceType.values())
+            .filter(x -> x.getId() == id)
+            .findAny()
+            .orElse(null);
+    }
+}

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/domain/EvidenceTypeTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/domain/EvidenceTypeTest.java
@@ -2,15 +2,36 @@ package org.flickit.assessment.core.application.domain;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EvidenceTypeTest {
 
     @Test
-    void testEvidenceType_IdOfTypesShouldNotBeChanged() {
+    void testEvidenceType_IdOfItemsShouldNotBeChanged() {
         assertEquals(1, EvidenceType.POSITIVE.getId());
         assertEquals(2, EvidenceType.NEGATIVE.getId());
+    }
 
+    @Test
+    void testEvidenceType_OrderOfItemsShouldNotBeChanged() {
+        assertEquals(0, EvidenceType.POSITIVE.ordinal());
+        assertEquals(1, EvidenceType.NEGATIVE.ordinal());
+    }
+
+    @Test
+    void testEvidenceType_NameOfItemsShouldNotBeChanged() {
+        assertEquals("POSITIVE", EvidenceType.POSITIVE.name());
+        assertEquals("NEGATIVE", EvidenceType.NEGATIVE.name());
+    }
+
+    @Test
+    void testEvidenceType_TitleOfItemsShouldNotBeChanged() {
+        assertEquals("positive", EvidenceType.POSITIVE.getTitle());
+        assertEquals("negative", EvidenceType.NEGATIVE.getTitle());
+    }
+
+    @Test
+    void testEvidenceType_SizeOfItemsShouldNotBeChanged() {
         assertEquals(2, EvidenceType.values().length);
     }
 }

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/domain/EvidenceTypeTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/domain/EvidenceTypeTest.java
@@ -1,0 +1,16 @@
+package org.flickit.assessment.core.application.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EvidenceTypeTest {
+
+    @Test
+    void testEvidenceType_IdOfTypesShouldNotBeChanged() {
+        assertEquals(1, EvidenceType.POSITIVE.getId());
+        assertEquals(2, EvidenceType.NEGATIVE.getId());
+
+        assertEquals(2, EvidenceType.values().length);
+    }
+}


### PR DESCRIPTION
An enum called 'EvidenceType' has been added to handle positive and negative evidences. This enum includes methods to get the ID, title and to find a value by an ID.