### PR TITLE
FAC-278 Remove questionId from EvidenceJpaEntity

### DIFF
--- a/flickit-assessment-common/src/main/resources/i18n/core/messages_en.properties
+++ b/flickit-assessment-common/src/main/resources/i18n/core/messages_en.properties
@@ -31,7 +31,7 @@ add-evidence.desc.notBlank=description may not be empty
 add-evidence.desc.size.min=description length must be more than 3
 add-evidence.desc.size.max=description length must be less than 1000
 add-evidence.assessmentId.notNull='assessmentId' may not be empty
-add-evidence.questionId.notNull='questionId' may not be empty
+add-evidence.questionRefNum.notNull='questionRefNum' may not be empty
 add-evidence.type.invalid=evidence type is not valid
 
 update-assessment.id.notNull='assessmentId' may not be null
@@ -51,7 +51,7 @@ get-answer-list.size.max='size' must be less than or equal to 100
 get-answer-list.page.min='page' must be greater than or equal to 0
 get-answer-list.assessmentResultId.notFound=no assessmentResult found by this 'assessmentId'
 
-get-evidence-list.questionId.notNull='questionId' may not be empty
+get-evidence-list.questionRefNum.notNull='questionRefNum' may not be empty
 get-evidence-list.assessmentId.notNull='assessmentId' may not be empty
 get-evidence-list.assessmentId.notFound='assessmentId' is not valid
 get-evidence-list.size.min='size' must be greater than or equal to 1

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/evidence/AddEvidenceRequestDto.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/evidence/AddEvidenceRequestDto.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 public record AddEvidenceRequestDto(
     String description,
     UUID assessmentId,
-    Long questionId,
+    UUID questionRefNum,
     String type
 ) {
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/evidence/AddEvidenceRestController.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/evidence/AddEvidenceRestController.java
@@ -30,7 +30,7 @@ public class AddEvidenceRestController {
         return new AddEvidenceUseCase.Param(
             requestDto.description(),
             requestDto.assessmentId(),
-            requestDto.questionId(),
+            requestDto.questionRefNum(),
             requestDto.type(),
             currentUserId
         );

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/evidence/GetEvidenceListRestController.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/evidence/GetEvidenceListRestController.java
@@ -22,17 +22,17 @@ public class GetEvidenceListRestController {
 
     @GetMapping("/evidences")
     public ResponseEntity<PaginatedResponse<EvidenceListItem>> getEvidenceList(
-        @RequestParam(value = "questionId", required = false) // validated in the use-case param
-        Long questionId,
+        @RequestParam(value = "questionRefNum", required = false) // validated in the use-case param
+        UUID questionRefNum,
         @RequestParam(value = "assessmentId", required = false) // validated in the use-case param
         UUID assessmentId,
         @RequestParam(defaultValue = "10") int size,
         @RequestParam(defaultValue = "0") int page) {
-        PaginatedResponse<EvidenceListItem> result = useCase.getEvidenceList(toParam(questionId, assessmentId, size, page));
+        PaginatedResponse<EvidenceListItem> result = useCase.getEvidenceList(toParam(questionRefNum, assessmentId, size, page));
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    private GetEvidenceListUseCase.Param toParam(Long questionId, UUID assessmentId, int size, int page) {
-        return new GetEvidenceListUseCase.Param(questionId, assessmentId, size, page);
+    private GetEvidenceListUseCase.Param toParam(UUID questionRefNum, UUID assessmentId, int size, int page) {
+        return new GetEvidenceListUseCase.Param(questionRefNum, assessmentId, size, page);
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/persistence/evidence/EvidenceMapper.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/persistence/evidence/EvidenceMapper.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EvidenceMapper {
 
-    public static EvidenceJpaEntity mapCreateParamToJpaEntity(CreateEvidencePort.Param param, UUID questionRefNum) {
+    public static EvidenceJpaEntity mapCreateParamToJpaEntity(CreateEvidencePort.Param param) {
         return new EvidenceJpaEntity(
             null,
             param.description(),
@@ -21,8 +21,7 @@ public class EvidenceMapper {
             param.createdById(),
             param.createdById(),
             param.assessmentId(),
-            param.questionId(),
-            questionRefNum,
+            param.questionRefNum(),
             param.type(),
             false
         );

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/evidence/AddEvidenceUseCase.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/evidence/AddEvidenceUseCase.java
@@ -32,8 +32,8 @@ public interface AddEvidenceUseCase {
         @NotNull(message = ADD_EVIDENCE_ASSESSMENT_ID_NOT_NULL)
         UUID assessmentId;
 
-        @NotNull(message = ADD_EVIDENCE_QUESTION_ID_NOT_NULL)
-        Long questionId;
+        @NotNull(message = ADD_EVIDENCE_QUESTION_REF_NUM_NOT_NULL)
+        UUID questionRefNum;
 
         @NotNull(message = COMMON_CURRENT_USER_ID_NOT_NULL)
         UUID createdById;
@@ -43,12 +43,12 @@ public interface AddEvidenceUseCase {
 
         public Param(String description,
                      UUID assessmentId,
-                     Long questionId,
+                     UUID questionRefNum,
                      String type,
                      UUID createdById) {
             this.description = description;
             this.assessmentId = assessmentId;
-            this.questionId = questionId;
+            this.questionRefNum = questionRefNum;
             this.createdById = createdById;
             this.type = type;
             this.validateSelf();

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/evidence/GetEvidenceListUseCase.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/evidence/GetEvidenceListUseCase.java
@@ -25,8 +25,8 @@ public interface GetEvidenceListUseCase {
     @EqualsAndHashCode(callSuper = false)
     class Param extends SelfValidating<Param> {
 
-        @NotNull(message = GET_EVIDENCE_LIST_QUESTION_ID_NOT_NULL)
-        Long questionId;
+        @NotNull(message = GET_EVIDENCE_LIST_QUESTION_REF_NUM_NOT_NULL)
+        UUID questionRefNum;
 
         @NotNull(message = GET_EVIDENCE_LIST_ASSESSMENT_ID_NOT_NULL)
         UUID assessmentId;
@@ -38,8 +38,8 @@ public interface GetEvidenceListUseCase {
         @Min(value = 0, message = GET_EVIDENCE_LIST_PAGE_MIN)
         int page;
 
-        public Param(Long questionId, UUID assessmentId, int size, int page) {
-            this.questionId = questionId;
+        public Param(UUID questionRefNum, UUID assessmentId, int size, int page) {
+            this.questionRefNum = questionRefNum;
             this.assessmentId = assessmentId;
             this.size = size;
             this.page = page;

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/evidence/CreateEvidencePort.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/evidence/CreateEvidencePort.java
@@ -12,7 +12,7 @@ public interface CreateEvidencePort {
                  LocalDateTime lastModificationTime,
                  UUID createdById,
                  UUID assessmentId,
-                 Long questionId,
+                 UUID questionRefNum,
                  Integer type) {
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/evidence/LoadEvidencesPort.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/evidence/LoadEvidencesPort.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public interface LoadEvidencesPort {
 
-    PaginatedResponse<EvidenceListItem> loadNotDeletedEvidences(Long questionId, UUID assessmentId, int page, int size);
+    PaginatedResponse<EvidenceListItem> loadNotDeletedEvidences(UUID questionRefNum, UUID assessmentId, int page, int size);
 
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/evidence/AddEvidenceService.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/evidence/AddEvidenceService.java
@@ -46,7 +46,7 @@ public class AddEvidenceService implements AddEvidenceUseCase {
             LocalDateTime.now(),
             param.getCreatedById(),
             param.getAssessmentId(),
-            param.getQuestionId(),
+            param.getQuestionRefNum(),
             param.getType() != null ? EvidenceType.valueOf(param.getType()).ordinal() : null
         );
     }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/evidence/GetEvidenceListService.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/evidence/GetEvidenceListService.java
@@ -24,7 +24,7 @@ public class GetEvidenceListService implements GetEvidenceListUseCase {
         if (!checkAssessmentExistencePort.existsById(param.getAssessmentId()))
             throw new ResourceNotFoundException(GET_EVIDENCE_LIST_ASSESSMENT_ID_NOT_FOUND);
         return loadEvidencesPort.loadNotDeletedEvidences(
-            param.getQuestionId(),
+            param.getQuestionRefNum(),
             param.getAssessmentId(),
             param.getPage(),
             param.getSize()

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/common/ErrorMessageKey.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/common/ErrorMessageKey.java
@@ -37,7 +37,7 @@ public class ErrorMessageKey {
     public static final String ADD_EVIDENCE_DESC_SIZE_MIN = "add-evidence.desc.size.min";
     public static final String ADD_EVIDENCE_DESC_SIZE_MAX = "add-evidence.desc.size.max";
     public static final String ADD_EVIDENCE_ASSESSMENT_ID_NOT_NULL = "add-evidence.assessmentId.notNull";
-    public static final String ADD_EVIDENCE_QUESTION_ID_NOT_NULL = "add-evidence.questionId.notNull";
+    public static final String ADD_EVIDENCE_QUESTION_REF_NUM_NOT_NULL = "add-evidence.questionRefNum.notNull";
     public static final String ADD_EVIDENCE_TYPE_INVALID = "add-evidence.type.invalid";
 
     public static final String UPDATE_ASSESSMENT_ID_NOT_NULL = "update-assessment.id.notNull";
@@ -66,7 +66,7 @@ public class ErrorMessageKey {
     public static final String GET_ATTRIBUTE_EVIDENCE_LIST_SIZE_MAX = "get-attribute-evidence-list.size.max";
     public static final String GET_ATTRIBUTE_EVIDENCE_LIST_PAGE_MIN = "get-attribute-evidence-list.page.min";
 
-    public static final String GET_EVIDENCE_LIST_QUESTION_ID_NOT_NULL = "get-evidence-list.questionId.notNull";
+    public static final String GET_EVIDENCE_LIST_QUESTION_REF_NUM_NOT_NULL = "get-evidence-list.questionRefNum.notNull";
     public static final String GET_EVIDENCE_LIST_ASSESSMENT_ID_NOT_NULL = "get-evidence-list.assessmentId.notNull";
     public static final String GET_EVIDENCE_LIST_ASSESSMENT_ID_NOT_FOUND = "get-evidence-list.assessmentId.notFound";
     public static final String GET_EVIDENCE_LIST_SIZE_MIN = "get-evidence-list.size.min";

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/port/in/evidence/AddEvidenceUseCaseParamTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/port/in/evidence/AddEvidenceUseCaseParamTest.java
@@ -21,8 +21,9 @@ class AddEvidenceUseCaseParamTest {
     void testAddEvidenceParam_DescriptionIsBlank_ErrorMessage() {
         UUID assessmentId = UUID.randomUUID();
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         var throwable = assertThrows(ConstraintViolationException.class,
-            () -> new AddEvidenceUseCase.Param("    ", assessmentId, 1L, "POSITIVE", createdById));
+            () -> new AddEvidenceUseCase.Param("    ", assessmentId, questionRefNum , "POSITIVE", createdById));
         assertThat(throwable).hasMessage("description: " + ADD_EVIDENCE_DESC_NOT_BLANK);
     }
 
@@ -30,48 +31,54 @@ class AddEvidenceUseCaseParamTest {
     void testAddEvidenceParam_DescriptionIsLessThanMin_ErrorMessage() {
         UUID assessmentId = UUID.randomUUID();
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         var throwable = assertThrows(ConstraintViolationException.class,
-            () -> new AddEvidenceUseCase.Param("ab", assessmentId, 1L, "POSITIVE", createdById));
+            () -> new AddEvidenceUseCase.Param("ab", assessmentId, questionRefNum, "POSITIVE", createdById));
         assertThat(throwable).hasMessage("description: " + ADD_EVIDENCE_DESC_SIZE_MIN);
     }
 
     @Test
     void testAddEvidenceParam_DescriptionSizeIsEqualToMin_Success() {
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         assertDoesNotThrow(
-            () -> new AddEvidenceUseCase.Param("abc", UUID.randomUUID(), 1L, "POSITIVE", createdById));
+            () -> new AddEvidenceUseCase.Param("abc", UUID.randomUUID(), questionRefNum, "POSITIVE", createdById));
     }
 
     @Test
     void testAddEvidenceParam_DescriptionSizeIsGreaterThanMax_ErrorMessage() {
         var assessmentId = UUID.randomUUID();
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         var desc = randomAlphabetic(1001);
         var throwable = assertThrows(ConstraintViolationException.class,
-            () -> new AddEvidenceUseCase.Param(desc, assessmentId, 1L, "POSITIVE", createdById));
+            () -> new AddEvidenceUseCase.Param(desc, assessmentId, questionRefNum, "POSITIVE", createdById));
         assertThat(throwable).hasMessage("description: " + ADD_EVIDENCE_DESC_SIZE_MAX);
     }
 
     @Test
     void testAddEvidenceParam_DescriptionSizeIsEqualToMax_Success() {
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         assertDoesNotThrow(
-            () -> new AddEvidenceUseCase.Param(randomAlphabetic(1000), UUID.randomUUID(), 1L, "POSITIVE", createdById));
+            () -> new AddEvidenceUseCase.Param(randomAlphabetic(1000), UUID.randomUUID(), questionRefNum, "POSITIVE", createdById));
     }
 
     @Test
     void testAddEvidenceParam_CreatedByIdIsNull_ErrorMessage() {
         UUID assessmentId = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         var throwable = assertThrows(ConstraintViolationException.class,
-            () -> new AddEvidenceUseCase.Param("desc", assessmentId, 1L, "POSITIVE", null));
+            () -> new AddEvidenceUseCase.Param("desc", assessmentId, questionRefNum, "POSITIVE", null));
         assertThat(throwable).hasMessage("createdById: " + COMMON_CURRENT_USER_ID_NOT_NULL);
     }
 
     @Test
     void testAddEvidenceParam_AssessmentIdIsNull_ErrorMessage() {
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         var throwable = assertThrows(ConstraintViolationException.class,
-            () -> new AddEvidenceUseCase.Param("desc", null, 1L, "POSITIVE", createdById));
+            () -> new AddEvidenceUseCase.Param("desc", null, questionRefNum, "POSITIVE", createdById));
         assertThat(throwable).hasMessage("assessmentId: " + ADD_EVIDENCE_ASSESSMENT_ID_NOT_NULL);
     }
 
@@ -82,15 +89,16 @@ class AddEvidenceUseCaseParamTest {
         var throwable = assertThrows(ConstraintViolationException.class,
             () -> new AddEvidenceUseCase.Param("desc", assessmentId, null, "POSITIVE", createdById)
         );
-        assertThat(throwable).hasMessage("questionId: " + ADD_EVIDENCE_QUESTION_ID_NOT_NULL);
+        assertThat(throwable).hasMessage("questionRefNum: " + ADD_EVIDENCE_QUESTION_REF_NUM_NOT_NULL);
     }
 
     @Test
     void testAddEvidenceParam_EvidenceTypeTitleIsNotValid_ErrorMessage() {
         UUID assessmentId = UUID.randomUUID();
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
         var throwable = assertThrows(ConstraintViolationException.class,
-            () -> new AddEvidenceUseCase.Param("desc", assessmentId, 1L, "notValid", createdById)
+            () -> new AddEvidenceUseCase.Param("desc", assessmentId, questionRefNum, "notValid", createdById)
         );
         assertThat(throwable).hasMessage("type: " + ADD_EVIDENCE_TYPE_INVALID);
     }
@@ -99,7 +107,8 @@ class AddEvidenceUseCaseParamTest {
     void testAddEvidenceParam_TypeIsNull_NoErrorMessage() {
         UUID assessmentId = UUID.randomUUID();
         UUID createdById = UUID.randomUUID();
+        UUID questionRefNum = UUID.randomUUID();
 
-        assertDoesNotThrow(() -> new AddEvidenceUseCase.Param("desc", assessmentId, 1L, null, createdById));
+        assertDoesNotThrow(() -> new AddEvidenceUseCase.Param("desc", assessmentId, questionRefNum, null, createdById));
     }
 }

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/port/in/evidence/GetEvidenceListUseCaseParamTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/port/in/evidence/GetEvidenceListUseCaseParamTest.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.flickit.assessment.core.common.ErrorMessageKey.GET_EVIDENCE_LIST_ASSESSMENT_ID_NOT_NULL;
-import static org.flickit.assessment.core.common.ErrorMessageKey.GET_EVIDENCE_LIST_QUESTION_ID_NOT_NULL;
+import static org.flickit.assessment.core.common.ErrorMessageKey.GET_EVIDENCE_LIST_QUESTION_REF_NUM_NOT_NULL;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,13 +20,14 @@ class GetEvidenceListUseCaseParamTest {
         UUID ASSESSMENT_ID = UUID.randomUUID();
         var throwable = assertThrows(ConstraintViolationException.class,
             () -> new GetEvidenceListUseCase.Param(null, ASSESSMENT_ID, 10, 0));
-        assertThat(throwable).hasMessage("questionId: " + GET_EVIDENCE_LIST_QUESTION_ID_NOT_NULL);
+        assertThat(throwable).hasMessage("questionRefNum: " + GET_EVIDENCE_LIST_QUESTION_REF_NUM_NOT_NULL);
     }
 
     @Test
     void testGetEvidenceListParam_NullAssessment_ReturnErrorMessage() {
+        UUID questionRefNum = UUID.randomUUID();
         var throwable = assertThrows(ConstraintViolationException.class,
-            () -> new GetEvidenceListUseCase.Param(0L, null, 10, 0));
+            () -> new GetEvidenceListUseCase.Param(questionRefNum, null, 10, 0));
         assertThat(throwable).hasMessage("assessmentId: " + GET_EVIDENCE_LIST_ASSESSMENT_ID_NOT_NULL);
     }
 }

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/evidence/AddEvidenceServiceTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/evidence/AddEvidenceServiceTest.java
@@ -39,7 +39,7 @@ class AddEvidenceServiceTest {
         AddEvidenceUseCase.Param param = new AddEvidenceUseCase.Param(
             "desc",
             UUID.randomUUID(),
-            1L,
+            UUID.randomUUID(),
             "POSITIVE",
             UUID.randomUUID()
         );
@@ -58,7 +58,7 @@ class AddEvidenceServiceTest {
         assertEquals(param.getDescription(), createPortParam.getValue().description());
         assertEquals(param.getCreatedById(), createPortParam.getValue().createdById());
         assertEquals(param.getAssessmentId(), createPortParam.getValue().assessmentId());
-        assertEquals(param.getQuestionId(), createPortParam.getValue().questionId());
+        assertEquals(param.getQuestionRefNum(), createPortParam.getValue().questionRefNum());
         assertNotNull(createPortParam.getValue().creationTime());
         assertNotNull(createPortParam.getValue().lastModificationTime());
     }
@@ -68,7 +68,7 @@ class AddEvidenceServiceTest {
         AddEvidenceUseCase.Param param = new AddEvidenceUseCase.Param(
             "desc",
             UUID.randomUUID(),
-            1L,
+            UUID.randomUUID(),
             "POSITIVE",
             UUID.randomUUID()
         );
@@ -87,7 +87,7 @@ class AddEvidenceServiceTest {
         AddEvidenceUseCase.Param param = new AddEvidenceUseCase.Param(
             "desc",
             UUID.randomUUID(),
-            1L,
+            UUID.randomUUID(),
             "POSITIVE",
             UUID.randomUUID()
         );

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/evidence/GetEvidenceListServiceTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/evidence/GetEvidenceListServiceTest.java
@@ -35,13 +35,13 @@ class GetEvidenceListServiceTest {
 
     @Test
     void testGetEvidenceList_ResultsFound_2ItemsReturned() {
-        Long question1Id = 1L;
+        UUID question1RefNum = UUID.randomUUID();
         EvidenceListItem evidence1Q1 = createEvidence();
         EvidenceListItem evidence2Q1 = createEvidence();
         UUID ASSESSMENT_ID = UUID.randomUUID();
 
         when(checkAssessmentExistencePort.existsById(ASSESSMENT_ID)).thenReturn(true);
-        when(loadEvidencesPort.loadNotDeletedEvidences(question1Id, ASSESSMENT_ID, 0, 10))
+        when(loadEvidencesPort.loadNotDeletedEvidences(question1RefNum, ASSESSMENT_ID, 0, 10))
             .thenReturn(new PaginatedResponse<>(
                 List.of(evidence1Q1, evidence2Q1),
                 0,
@@ -50,17 +50,17 @@ class GetEvidenceListServiceTest {
                 "DESC",
                 2));
 
-        PaginatedResponse<EvidenceListItem> result = service.getEvidenceList(new Param(question1Id, ASSESSMENT_ID, 10, 0));
+        PaginatedResponse<EvidenceListItem> result = service.getEvidenceList(new Param(question1RefNum, ASSESSMENT_ID, 10, 0));
 
         assertEquals(2, result.getItems().size());
     }
 
     @Test
     void testGetEvidenceList_ResultsFound_NoItemReturned() {
-        Long QUESTION2_ID = 2L;
+        UUID QUESTION2_REF_NUM = UUID.randomUUID();
         UUID ASSESSMENT_ID = UUID.randomUUID();
         when(checkAssessmentExistencePort.existsById(ASSESSMENT_ID)).thenReturn(true);
-        when(loadEvidencesPort.loadNotDeletedEvidences(QUESTION2_ID, ASSESSMENT_ID, 0, 10))
+        when(loadEvidencesPort.loadNotDeletedEvidences(QUESTION2_REF_NUM, ASSESSMENT_ID, 0, 10))
             .thenReturn(new PaginatedResponse<>(
                 new ArrayList<>(),
                 0,
@@ -69,7 +69,7 @@ class GetEvidenceListServiceTest {
                 "DESC",
                 0));
 
-        PaginatedResponse<EvidenceListItem> result = service.getEvidenceList(new Param(QUESTION2_ID, ASSESSMENT_ID, 10, 0));
+        PaginatedResponse<EvidenceListItem> result = service.getEvidenceList(new Param(QUESTION2_REF_NUM, ASSESSMENT_ID, 10, 0));
 
         assertEquals(0, result.getItems().size());
     }
@@ -77,7 +77,8 @@ class GetEvidenceListServiceTest {
     @Test
     void testGetEvidenceList_InvalidAssessmentId_ThrowNotFoundException() {
         UUID ASSESSMENT_ID = UUID.randomUUID();
-        Param param = new Param(0L, ASSESSMENT_ID, 10, 0);
+        UUID QUESTION_REF_NUM = UUID.randomUUID();
+        Param param = new Param(QUESTION_REF_NUM, ASSESSMENT_ID, 10, 0);
         when(checkAssessmentExistencePort.existsById(ASSESSMENT_ID)).thenReturn(false);
 
         assertThrows(ResourceNotFoundException.class, () -> service.getEvidenceList(param));

--- a/flickit-assessment-core/src/test/resources/postman/flickit-assessment-core.postman_collection.json
+++ b/flickit-assessment-core/src/test/resources/postman/flickit-assessment-core.postman_collection.json
@@ -255,7 +255,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"description\": \"description1\",\n    \"assessmentId\": \"136960fa-4040-4f3b-ac34-a71a67d29941\",\n    \"questionId\": 9110,\n    \"type\": \"POSITIVE\"\n}",
+					"raw": "{\n    \"description\": \"description1\",\n    \"assessmentId\": \"136960fa-4040-4f3b-ac34-a71a67d29941\",\n    \"questionRefNum\": \"c1f250a8-8daa-47e4-a9e3-5da95b24caaa\",\n    \"type\": \"POSITIVE\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -397,7 +397,7 @@
 					}
 				],
 				"url": {
-					"raw": "{{base_url}}/{{api_path}}/evidences?questionId=1&assessmentId=c4e0b4a4-66a1-4383-872f-be9fc6c3cecb&size=10&page=0",
+					"raw": "{{base_url}}/{{api_path}}/evidences?questionRefNum=c1f250a8-8daa-47e4-a9e3-5da95b24caaa&assessmentId=136960fa-4040-4f3b-ac34-a71a67d29941&size=10&page=0",
 					"host": [
 						"{{base_url}}"
 					],
@@ -407,12 +407,12 @@
 					],
 					"query": [
 						{
-							"key": "questionId",
-							"value": "1"
+							"key": "questionRefNum",
+							"value": "c1f250a8-8daa-47e4-a9e3-5da95b24caaa"
 						},
 						{
 							"key": "assessmentId",
-							"value": "c4e0b4a4-66a1-4383-872f-be9fc6c3cecb"
+							"value": "136960fa-4040-4f3b-ac34-a71a67d29941"
 						},
 						{
 							"key": "size",

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/core/evidence/EvidenceJpaEntity.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/core/evidence/EvidenceJpaEntity.java
@@ -42,9 +42,6 @@ public class EvidenceJpaEntity {
     @Column(name = "assessment_id", nullable = false)
     private UUID assessmentId;
 
-    @Column(name = "question_id", nullable = false)
-    private Long questionId;
-
     @Column(name = "question_ref_num", nullable = false)
     private UUID questionRefNum;
 

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/core/evidence/EvidenceJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/core/evidence/EvidenceJpaRepository.java
@@ -12,8 +12,8 @@ import java.util.UUID;
 
 public interface EvidenceJpaRepository extends JpaRepository<EvidenceJpaEntity, UUID> {
 
-    Page<EvidenceJpaEntity> findByQuestionIdAndAssessmentIdAndDeletedFalseOrderByLastModificationTimeDesc(
-        Long questionId, UUID assessmentId, Pageable pageable);
+    Page<EvidenceJpaEntity> findByQuestionRefNumAndAssessmentIdAndDeletedFalseOrderByLastModificationTimeDesc(
+        UUID questionRefNum, UUID assessmentId, Pageable pageable);
 
     @Modifying
     @Query("""
@@ -43,7 +43,7 @@ public interface EvidenceJpaRepository extends JpaRepository<EvidenceJpaEntity, 
     @Query(value = """
             SELECT evd.description
             FROM QuestionJpaEntity q
-                LEFT JOIN EvidenceJpaEntity evd ON q.id = evd.questionId
+                LEFT JOIN EvidenceJpaEntity evd ON q.refNum = evd.questionRefNum
                 WHERE evd.assessmentId = :assessmentId
                     AND evd.type = :type
                     AND evd.deleted = false

--- a/flickit-assessment-data/src/main/resources/liquibase/changelog-0.15.xml
+++ b/flickit-assessment-data/src/main/resources/liquibase/changelog-0.15.xml
@@ -435,4 +435,8 @@
         <dropDefaultValue tableName="fak_question" columnName="advisable"/>
     </changeSet>
 
+    <changeSet id="0.15-63" author="Ali Sedaghat">
+        <dropNotNullConstraint tableName="fac_evidence" columnName="question_id"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Due to removing questionId from EvidenceJpaEntity and holding the corresponding column in the Database, the question_id should be nullable. Using questionRefNum instead of questionId, affects AddEvidence and GetEvidenceList services and their corresponding tests.