### PR TITLE
FAC-287 Add next question index to questionnaires progress service

### DIFF
--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/questionnaire/GetQuestionnairesProgressUseCase.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/questionnaire/GetQuestionnairesProgressUseCase.java
@@ -30,6 +30,6 @@ public interface GetQuestionnairesProgressUseCase {
     record Result(List<QuestionnaireProgress> questionnairesProgress){
     }
 
-    record QuestionnaireProgress(Long id, Integer answersCount) {
+    record QuestionnaireProgress(Long id, Integer answersCount, Integer nextQuestion) {
     }
 }

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/questionnaire/GetQuestionnairesProgressServiceTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/questionnaire/GetQuestionnairesProgressServiceTest.java
@@ -34,8 +34,8 @@ class GetQuestionnairesProgressServiceTest {
         UUID assessmentId = UUID.randomUUID();
         Param useCaseParam = new Param(assessmentId);
 
-        List<QuestionnaireProgress> expectedQProgresses = Arrays.asList(new QuestionnaireProgress(1L, 15),
-            new QuestionnaireProgress(2L, 17));
+        List<QuestionnaireProgress> expectedQProgresses = Arrays.asList(new QuestionnaireProgress(1L, 15, 2),
+            new QuestionnaireProgress(2L, 17, 3));
         when(getQuestionnairesProgressPort.getQuestionnairesProgressByAssessmentId(assessmentId)).thenReturn(expectedQProgresses);
 
         Result result = service.getQuestionnairesProgress(useCaseParam);

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/question/FirstUnansweredQuestionView.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/question/FirstUnansweredQuestionView.java
@@ -1,0 +1,8 @@
+package org.flickit.assessment.data.jpa.kit.question;
+
+public interface FirstUnansweredQuestionView {
+
+    Long getQuestionnaireId();
+
+    Integer getIndex();
+}


### PR DESCRIPTION
To specify the first unanswered question of each questionnaire of an assessment, the nextQuestion field has been added to response of GetQuestionnairesProgressService. Due to the this change, corresponding test also has changed.