### PR TITLE
FAC-278 Get attributes info of a subject

### DIFF
--- a/flickit-assessment-common/src/main/resources/i18n/core/messages_en.properties
+++ b/flickit-assessment-common/src/main/resources/i18n/core/messages_en.properties
@@ -94,6 +94,10 @@ get-subject-progress.assessmentResultId.notFound=no assessmentResult found by th
 get-subject-progress.subject.id.notNull='subjectId' may not be empty
 get-subject-progress.subject.id.notFound=no subject found by this 'subjectId'
 
+get-subject-attributes.assessment.id.notNull='assessmentId' may not be empty
+get-subject-attributes.subject.id.notNull='subjectId' may not be empty
+get-subject-attributes.subject.id.notFound='subjectId' is not valid
+
 get-assessment.assessmentId.notNull='assessmentId' may not be empty
 get-assessment.assessmentId.notFound=no assessment found by this 'assessmentId'
 

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/subject/GetSubjectAttributesResponseDto.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/subject/GetSubjectAttributesResponseDto.java
@@ -1,0 +1,8 @@
+package org.flickit.assessment.core.adapter.in.rest.subject;
+
+import org.flickit.assessment.core.application.port.in.subject.GetSubjectAttributesUseCase.SubjectAttribute;
+
+import java.util.List;
+
+public record GetSubjectAttributesResponseDto(List<SubjectAttribute> items) {
+}

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/subject/GetSubjectAttributesRestController.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/subject/GetSubjectAttributesRestController.java
@@ -1,0 +1,37 @@
+package org.flickit.assessment.core.adapter.in.rest.subject;
+
+import lombok.RequiredArgsConstructor;
+import org.flickit.assessment.common.config.jwt.UserContext;
+import org.flickit.assessment.core.application.port.in.subject.GetSubjectAttributesUseCase;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class GetSubjectAttributesRestController {
+
+    private final UserContext userContext;
+    private final GetSubjectAttributesUseCase useCase;
+
+    @GetMapping("/assessments/{assessmentId}/subjects/{subjectId}/attributes-info")
+    public ResponseEntity<GetSubjectAttributesResponseDto> getSubjectProgress(
+        @PathVariable("assessmentId") UUID assessmentId,
+        @PathVariable("subjectId") Long subjectId) {
+        UUID currentUserId = userContext.getUser().id();
+        var response = toResponse(useCase.getSubjectAttributes(toParam(assessmentId, subjectId, currentUserId)));
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    private GetSubjectAttributesUseCase.Param toParam(UUID assessmentId, Long subjectId, UUID currentUserId) {
+        return new GetSubjectAttributesUseCase.Param(assessmentId, subjectId, currentUserId);
+    }
+
+    private GetSubjectAttributesResponseDto toResponse(GetSubjectAttributesUseCase.Result result) {
+        return new GetSubjectAttributesResponseDto(result.subjectAttributes());
+    }
+}

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/persistence/kit/attribute/AttributePersistenceJpaAdapter.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/persistence/kit/attribute/AttributePersistenceJpaAdapter.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.flickit.assessment.common.exception.ResourceNotFoundException;
 import org.flickit.assessment.core.application.port.in.attribute.GetAttributeScoreDetailUseCase.QuestionScore;
 import org.flickit.assessment.core.application.port.in.attribute.GetAttributeScoreDetailUseCase.Questionnaire;
+import org.flickit.assessment.core.application.port.in.subject.GetSubjectAttributesUseCase.SubjectAttribute;
 import org.flickit.assessment.core.application.port.out.attribute.LoadAttributeScoreDetailPort;
+import org.flickit.assessment.core.application.port.out.subject.LoadSubjectAttributesPort;
 import org.flickit.assessment.data.jpa.core.answer.AnswerJpaEntity;
 import org.flickit.assessment.data.jpa.core.assessmentresult.AssessmentResultJpaRepository;
 import org.flickit.assessment.data.jpa.kit.asnweroptionimpact.AnswerOptionImpactJpaEntity;
@@ -21,7 +23,7 @@ import static org.flickit.assessment.core.common.ErrorMessageKey.GET_ATTRIBUTE_S
 
 @Component("coreAttributePersistenceJpaAdapter")
 @RequiredArgsConstructor
-public class AttributePersistenceJpaAdapter implements LoadAttributeScoreDetailPort {
+public class AttributePersistenceJpaAdapter implements LoadAttributeScoreDetailPort, LoadSubjectAttributesPort {
 
     private final AttributeJpaRepository repository;
     private final AssessmentResultJpaRepository assessmentResultRepository;
@@ -65,5 +67,13 @@ public class AttributePersistenceJpaAdapter implements LoadAttributeScoreDetailP
         if(optionImpact == null) // if there exists an answer and notApplicable != true and no option is selected
             return 0.0;
         return optionImpact.getValue();
+    }
+
+    @Override
+    public List<SubjectAttribute> loadBySubjectIdAndAssessmentId(Long subjectId, UUID assessmentId) {
+        var subjectAttrViews = repository.findBySubjectIdAndAssessmentId(subjectId, assessmentId);
+        return subjectAttrViews.stream()
+            .map(e -> new SubjectAttribute(e.getAttributeId(), e.getMaturityLevelId(), e.getWeight()))
+            .toList();
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/persistence/kit/subject/SubjectPersistenceJpaAdapter.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/persistence/kit/subject/SubjectPersistenceJpaAdapter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.flickit.assessment.core.adapter.out.persistence.kit.attribute.AttributeMapper;
 import org.flickit.assessment.core.application.domain.QualityAttribute;
 import org.flickit.assessment.core.application.domain.Subject;
+import org.flickit.assessment.core.application.port.out.subject.CheckSubjectKitExistencePort;
 import org.flickit.assessment.core.application.port.out.subject.LoadSubjectPort;
 import org.flickit.assessment.core.application.port.out.subject.LoadSubjectsPort;
 import org.flickit.assessment.data.jpa.kit.subject.SubjectJpaRepository;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.flickit.assessment.core.adapter.out.persistence.kit.subject.SubjectMapper.mapToDomainModel;
 
@@ -18,7 +20,8 @@ import static org.flickit.assessment.core.adapter.out.persistence.kit.subject.Su
 @RequiredArgsConstructor
 public class SubjectPersistenceJpaAdapter implements
     LoadSubjectsPort,
-    LoadSubjectPort {
+    LoadSubjectPort,
+    CheckSubjectKitExistencePort {
 
     private final SubjectJpaRepository repository;
 
@@ -39,5 +42,10 @@ public class SubjectPersistenceJpaAdapter implements
     public Optional<Subject> loadByIdAndKitVersionId(long id, long kitVersionId) {
         return repository.findByIdAndKitVersionId(id, kitVersionId)
             .map(entity -> mapToDomainModel(entity, null));
+    }
+
+    @Override
+    public boolean existsByIdAndAssessmentId(Long subjectId, UUID assessmentId) {
+        return repository.existsByIdAndAssessmentId(subjectId, assessmentId);
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/subject/GetSubjectAttributesUseCase.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/subject/GetSubjectAttributesUseCase.java
@@ -1,0 +1,42 @@
+package org.flickit.assessment.core.application.port.in.subject;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.flickit.assessment.common.application.SelfValidating;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_ID_NOT_NULL;
+import static org.flickit.assessment.core.common.ErrorMessageKey.*;
+
+public interface GetSubjectAttributesUseCase {
+
+    Result getSubjectAttributes(Param param);
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    class Param extends SelfValidating<GetSubjectProgressUseCase.Param> {
+
+        @NotNull(message = GET_SUBJECT_ATTRIBUTES_ASSESSMENT_ID_NOT_NULL)
+        UUID assessmentId;
+
+        @NotNull(message = GET_SUBJECT_ATTRIBUTES_SUBJECT_ID_NOT_NULL)
+        Long subjectId;
+
+        @NotNull(message = COMMON_CURRENT_USER_ID_NOT_NULL)
+        UUID currentUserId;
+
+        public Param(UUID assessmentId, Long subjectId, UUID currentUserId) {
+            this.assessmentId = assessmentId;
+            this.subjectId = subjectId;
+            this.currentUserId = currentUserId;
+            this.validateSelf();
+        }
+    }
+
+    record Result(List<SubjectAttribute> subjectAttributes) { }
+
+    record SubjectAttribute(Long id, Long maturityLevelId, Integer weight) {}
+}

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/subject/CheckSubjectKitExistencePort.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/subject/CheckSubjectKitExistencePort.java
@@ -1,0 +1,8 @@
+package org.flickit.assessment.core.application.port.out.subject;
+
+import java.util.UUID;
+
+public interface CheckSubjectKitExistencePort {
+
+    boolean existsByIdAndAssessmentId(Long subjectId, UUID assessmentId);
+}

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/subject/LoadSubjectAttributesPort.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/subject/LoadSubjectAttributesPort.java
@@ -1,0 +1,11 @@
+package org.flickit.assessment.core.application.port.out.subject;
+
+import org.flickit.assessment.core.application.port.in.subject.GetSubjectAttributesUseCase.SubjectAttribute;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface LoadSubjectAttributesPort {
+
+    List<SubjectAttribute> loadBySubjectIdAndAssessmentId(Long subjectId, UUID assessmentId);
+}

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/subject/GetSubjectAttributesService.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/subject/GetSubjectAttributesService.java
@@ -1,0 +1,37 @@
+package org.flickit.assessment.core.application.service.subject;
+
+import lombok.RequiredArgsConstructor;
+import org.flickit.assessment.common.exception.AccessDeniedException;
+import org.flickit.assessment.common.exception.ResourceNotFoundException;
+import org.flickit.assessment.core.application.port.in.subject.GetSubjectAttributesUseCase;
+import org.flickit.assessment.core.application.port.out.assessment.CheckUserAssessmentAccessPort;
+import org.flickit.assessment.core.application.port.out.subject.CheckSubjectKitExistencePort;
+import org.flickit.assessment.core.application.port.out.subject.LoadSubjectAttributesPort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_NOT_ALLOWED;
+import static org.flickit.assessment.core.common.ErrorMessageKey.GET_SUBJECT_ATTRIBUTES_SUBJECT_ID_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetSubjectAttributesService implements GetSubjectAttributesUseCase {
+
+    private final CheckUserAssessmentAccessPort checkUserAssessmentAccessPort;
+    private final CheckSubjectKitExistencePort checkSubjectKitExistencePort;
+    private final LoadSubjectAttributesPort loadSubjectAttributesPort;
+
+    @Override
+    public Result getSubjectAttributes(Param param) {
+        if (!checkUserAssessmentAccessPort.hasAccess(param.getAssessmentId(), param.getCurrentUserId()))
+            throw new AccessDeniedException(COMMON_CURRENT_USER_NOT_ALLOWED);
+
+        if (!checkSubjectKitExistencePort.existsByIdAndAssessmentId(param.getSubjectId(), param.getAssessmentId()))
+            throw new ResourceNotFoundException(GET_SUBJECT_ATTRIBUTES_SUBJECT_ID_NOT_FOUND);
+
+        var subjectAttributes = loadSubjectAttributesPort.loadBySubjectIdAndAssessmentId(param.getSubjectId(),
+            param.getAssessmentId());
+        return new Result(subjectAttributes);
+    }
+}

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/common/ErrorMessageKey.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/common/ErrorMessageKey.java
@@ -100,6 +100,10 @@ public class ErrorMessageKey {
     public static final String GET_SUBJECT_PROGRESS_SUBJECT_ID_NOT_NULL = "get-subject-progress.subject.id.notNull";
     public static final String GET_SUBJECT_PROGRESS_SUBJECT_ID_NOT_FOUND = "get-subject-progress.subject.id.notFound";
 
+    public static final String GET_SUBJECT_ATTRIBUTES_ASSESSMENT_ID_NOT_NULL = "get-subject-attributes.assessment.id.notNull";
+    public static final String GET_SUBJECT_ATTRIBUTES_SUBJECT_ID_NOT_NULL = "get-subject-attributes.subject.id.notNull";
+    public static final String GET_SUBJECT_ATTRIBUTES_SUBJECT_ID_NOT_FOUND = "get-subject-attributes.subject.id.notFound";
+
     public static final String GET_ASSESSMENT_ASSESSMENT_ID_NOT_NULL = "get-assessment.assessmentId.notNull";
     public static final String GET_ASSESSMENT_ASSESSMENT_ID_NOT_FOUND = "get-assessment.assessmentId.notFound";
 

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/subject/GetSubjectAttributesServiceTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/subject/GetSubjectAttributesServiceTest.java
@@ -1,0 +1,76 @@
+package org.flickit.assessment.core.application.service.subject;
+
+import org.flickit.assessment.common.exception.AccessDeniedException;
+import org.flickit.assessment.common.exception.ResourceNotFoundException;
+import org.flickit.assessment.core.application.port.in.subject.GetSubjectAttributesUseCase;
+import org.flickit.assessment.core.application.port.in.subject.GetSubjectAttributesUseCase.Param;
+import org.flickit.assessment.core.application.port.out.assessment.CheckUserAssessmentAccessPort;
+import org.flickit.assessment.core.application.port.out.subject.CheckSubjectKitExistencePort;
+import org.flickit.assessment.core.application.port.out.subject.LoadSubjectAttributesPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetSubjectAttributesServiceTest {
+
+    @InjectMocks
+    private GetSubjectAttributesService getSubjectAttributesService;
+
+    @Mock
+    private CheckUserAssessmentAccessPort checkUserAssessmentAccessPort;
+
+    @Mock
+    private CheckSubjectKitExistencePort checkSubjectKitExistencePort;
+
+    @Mock
+    private LoadSubjectAttributesPort loadSubjectAttributesPort;
+
+    @Test
+    void testGetSubjectAttributes_validParams_ItemsReturned() {
+        UUID assessmentId = UUID.randomUUID();
+        UUID currentUserId = UUID.randomUUID();
+        Param param = new Param(assessmentId, 1L, currentUserId);
+        var subjectAttributes = List.of(new GetSubjectAttributesUseCase.SubjectAttribute(1L, 2L, 3));
+
+        when(checkUserAssessmentAccessPort.hasAccess(assessmentId, currentUserId)).thenReturn(true);
+        when(checkSubjectKitExistencePort.existsByIdAndAssessmentId(param.getSubjectId(), assessmentId)).thenReturn(true);
+        when(loadSubjectAttributesPort.loadBySubjectIdAndAssessmentId(param.getSubjectId(), assessmentId)).thenReturn(subjectAttributes);
+
+        var result = getSubjectAttributesService.getSubjectAttributes(param);
+        assertEquals(1L, result.subjectAttributes().get(0).id());
+        assertEquals(2L, result.subjectAttributes().get(0).maturityLevelId());
+        assertEquals(3, result.subjectAttributes().get(0).weight());
+    }
+
+    @Test
+    void testGetSubjectAttributes_InvalidAssessmentId_ThrowsAccessDeniedException() {
+        UUID assessmentId = UUID.randomUUID();
+        UUID currentUserId = UUID.randomUUID();
+        Param param = new Param(assessmentId, 1L, currentUserId);
+
+        when(checkUserAssessmentAccessPort.hasAccess(assessmentId, currentUserId)).thenReturn(false);
+
+        assertThrows(AccessDeniedException.class, () -> getSubjectAttributesService.getSubjectAttributes(param));
+    }
+
+    @Test
+    void testGetSubjectAttributes_InvalidSubjectId_ThrowsResourceNotFoundException() {
+        UUID assessmentId = UUID.randomUUID();
+        UUID currentUserId = UUID.randomUUID();
+        Param param = new Param(assessmentId, 1L, currentUserId);
+
+        when(checkUserAssessmentAccessPort.hasAccess(assessmentId, currentUserId)).thenReturn(true);
+        when(checkSubjectKitExistencePort.existsByIdAndAssessmentId(param.getSubjectId(), assessmentId)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> getSubjectAttributesService.getSubjectAttributes(param));
+    }
+}

--- a/flickit-assessment-core/src/test/resources/postman/flickit-assessment-core.postman_collection.json
+++ b/flickit-assessment-core/src/test/resources/postman/flickit-assessment-core.postman_collection.json
@@ -822,6 +822,34 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Get Subject Attributes",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "{{authorization_header}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{base_url}}/{{api_path}}/assessments/8280e75b-ed71-4c82-9fac-920c52efb26c/subjects/331/attributes-info",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"{{api_path}}",
+						"assessments",
+						"8280e75b-ed71-4c82-9fac-920c52efb26c",
+						"subjects",
+						"331",
+						"attributes-info"
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"variable": [

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/attribute/AttributeJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/attribute/AttributeJpaRepository.java
@@ -66,4 +66,20 @@ public interface AttributeJpaRepository extends JpaRepository<AttributeJpaEntity
         WHERE a.id = :attributeId
         """)
     UUID findRefNumById(@Param("attributeId") Long attributeId);
+
+    @Query("""
+        SELECT
+            a.id AS attributeId,
+            av.maturityLevelId AS maturityLevelId,
+            a.weight AS weight
+        FROM SubjectJpaEntity s JOIN AttributeJpaEntity a ON s.id = a.subject
+        JOIN QualityAttributeValueJpaEntity av ON av.attributeRefNum = a.refNum
+        JOIN AssessmentResultJpaEntity ar ON av.assessmentResult.id = ar.id
+        JOIN AssessmentJpaEntity asm ON ar.assessment.id = asm.id
+        WHERE
+            s.id = :subjectId
+            AND asm.id = :assessmentId
+    """)
+    List<SubjectAttributeView> findBySubjectIdAndAssessmentId(@Param("subjectId") Long subjectId,
+                                                              @Param("assessmentId") UUID assessmentId);
 }

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/attribute/SubjectAttributeView.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/attribute/SubjectAttributeView.java
@@ -1,0 +1,10 @@
+package org.flickit.assessment.data.jpa.kit.attribute;
+
+public interface SubjectAttributeView {
+
+    Long getAttributeId();
+
+    Long getMaturityLevelId();
+
+    Integer getWeight();
+}

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/subject/SubjectJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/subject/SubjectJpaRepository.java
@@ -54,4 +54,16 @@ public interface SubjectJpaRepository extends JpaRepository<SubjectJpaEntity, Lo
             WHERE s.id = :subjectId
         """)
     UUID findRefNumById(@Param(value = "subjectId") Long subjectId);
+
+    @Query("""
+        SELECT CASE WHEN EXISTS (SELECT 1
+        FROM SubjectJpaEntity s JOIN KitVersionJpaEntity kv ON s.kitVersionId = kv.id
+        JOIN AssessmentKitJpaEntity k ON kv.kit.id = k.id
+        JOIN AssessmentJpaEntity asm ON asm.assessmentKitId = k.id
+        WHERE
+            s.id = :subjectId
+            AND asm.id = :assessmentId)
+        THEN TRUE ELSE FALSE END
+    """)
+    boolean existsByIdAndAssessmentId(@Param("subjectId") Long subjectId, @Param("assessmentId") UUID assessmentId);
 }


### PR DESCRIPTION
A Service implemented to return attributes info of subject of an assessment. The info includes: attributed id, maturity level id of attribute and its weight. New tests added corresponding to the service, and new API added to assessment core collection of postman.