### PR TITLE
FAC-302 Change output of ReportAssessmentService

### DIFF
--- a/flickit-assessment-common/src/main/resources/i18n/core/messages_en.properties
+++ b/flickit-assessment-common/src/main/resources/i18n/core/messages_en.properties
@@ -67,9 +67,11 @@ get-attribute-evidence-list.size.min='size' must be greater than or equal to 1
 get-attribute-evidence-list.size.max='size' must be less than or equal to 100
 get-attribute-evidence-list.page.min='page' must be greater than or equal to 0
 
+report-assessment-assessment.id.notFound='assessmentId' is not valid
 report-assessment.assessment.id.notNull='assessmentId' may not be empty
 report-assessment.assessmentResult.notFound=no assessmentResult found by this 'assessmentId'
-report-assessment.maturityLevelId.notFound='maturityLevelId' is not valid
+report-assessment.assessmentKit.notFound=no assessmentKit found by this 'assessmentId'
+report-assessment.expertGroup.notFound ='expertGroupId' is not valid
 
 get-assessment-progress.assessment.id.notNull='assessmentId' may not be empty
 get-assessment-progress.assessmentResult.notFound=no assessmentResult found by this 'assessmentId'

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/assessment/AssessmentReportResponseDto.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/assessment/AssessmentReportResponseDto.java
@@ -1,0 +1,14 @@
+package org.flickit.assessment.core.adapter.in.rest.assessment;
+
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.SubjectReportItem;
+import org.flickit.assessment.core.application.port.in.assessment.ReportAssessmentUseCase.Result.TopAttribute;
+
+import java.util.List;
+
+public record AssessmentReportResponseDto(
+    AssessmentReportItem assessment,
+    List<TopAttribute> topStrengths,
+    List<TopAttribute> topWeaknesses,
+    List<SubjectReportItem> subjects
+) {}

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/assessment/ReportAssessmentRestController.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/in/rest/assessment/ReportAssessmentRestController.java
@@ -1,7 +1,7 @@
 package org.flickit.assessment.core.adapter.in.rest.assessment;
 
 import lombok.RequiredArgsConstructor;
-import org.flickit.assessment.core.application.domain.report.AssessmentReport;
+import org.flickit.assessment.common.config.jwt.UserContext;
 import org.flickit.assessment.core.application.port.in.assessment.ReportAssessmentUseCase;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,15 +16,24 @@ import java.util.UUID;
 public class ReportAssessmentRestController {
 
     private final ReportAssessmentUseCase useCase;
+    private final UserContext userContext;
 
     @GetMapping("/assessments/{assessmentId}/report")
-    public ResponseEntity<AssessmentReport> reportAssessment(@PathVariable("assessmentId") UUID assessmentId) {
-        var param = toParam(assessmentId);
-        var result = useCase.reportAssessment(param);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+    public ResponseEntity<AssessmentReportResponseDto> reportAssessment(@PathVariable("assessmentId") UUID assessmentId) {
+        UUID currentUserId = userContext.getUser().id();
+        var param = toParam(assessmentId, currentUserId);
+        var response = toResponse(useCase.reportAssessment(param));
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    private ReportAssessmentUseCase.Param toParam(UUID assessmentId) {
-        return new ReportAssessmentUseCase.Param(assessmentId);
+    private AssessmentReportResponseDto toResponse(ReportAssessmentUseCase.Result result) {
+        return new AssessmentReportResponseDto(result.assessment(),
+            result.topStrengths(),
+            result.topWeaknesses(),
+            result.subjects());
+    }
+
+    private ReportAssessmentUseCase.Param toParam(UUID assessmentId, UUID currentUserId) {
+        return new ReportAssessmentUseCase.Param(assessmentId, currentUserId);
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/report/LoadAssessmentReportInfoAdapter.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/adapter/out/report/LoadAssessmentReportInfoAdapter.java
@@ -3,25 +3,43 @@ package org.flickit.assessment.core.adapter.out.report;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.flickit.assessment.common.exception.ResourceNotFoundException;
-import org.flickit.assessment.core.adapter.out.persistence.kit.maturitylevel.MaturityLevelPersistenceJpaAdapter;
 import org.flickit.assessment.core.application.domain.*;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AttributeReportItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.SubjectReportItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.SubjectReportItem.SubjectMaturityLevel;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem.AssessmentMaturityLevel;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem.AssessmentKitItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem.AssessmentKitItem.ExpertGroup;
 import org.flickit.assessment.core.application.port.out.assessmentresult.LoadAssessmentReportInfoPort;
 import org.flickit.assessment.data.jpa.core.assessment.AssessmentJpaEntity;
 import org.flickit.assessment.data.jpa.core.assessmentresult.AssessmentResultJpaEntity;
 import org.flickit.assessment.data.jpa.core.assessmentresult.AssessmentResultJpaRepository;
+import org.flickit.assessment.data.jpa.core.attributevalue.QualityAttributeValueJpaEntity;
+import org.flickit.assessment.data.jpa.core.attributevalue.QualityAttributeValueJpaRepository;
 import org.flickit.assessment.data.jpa.core.subjectvalue.SubjectValueJpaEntity;
 import org.flickit.assessment.data.jpa.core.subjectvalue.SubjectValueJpaRepository;
+import org.flickit.assessment.data.jpa.kit.assessmentkit.AssessmentKitJpaEntity;
+import org.flickit.assessment.data.jpa.kit.assessmentkit.AssessmentKitJpaRepository;
+import org.flickit.assessment.data.jpa.kit.attribute.AttributeJpaEntity;
+import org.flickit.assessment.data.jpa.kit.attribute.AttributeJpaRepository;
+import org.flickit.assessment.data.jpa.kit.maturitylevel.MaturityLevelJpaEntity;
+import org.flickit.assessment.data.jpa.kit.maturitylevel.MaturityLevelJpaRepository;
+import org.flickit.assessment.data.jpa.kit.subject.SubjectJpaEntity;
+import org.flickit.assessment.data.jpa.kit.subject.SubjectJpaRepository;
+import org.flickit.assessment.data.jpa.users.expertgroup.ExpertGroupJpaEntity;
+import org.flickit.assessment.data.jpa.users.expertgroup.ExpertGroupJpaRepository;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
-import static org.flickit.assessment.core.adapter.out.persistence.assessment.AssessmentMapper.mapToDomainModel;
-import static org.flickit.assessment.core.common.ErrorMessageKey.REPORT_ASSESSMENT_ASSESSMENT_RESULT_NOT_FOUND;
-import static org.flickit.assessment.core.common.ErrorMessageKey.REPORT_ASSESSMENT_MATURITY_LEVEL_NOT_FOUND;
+import static org.flickit.assessment.core.common.ErrorMessageKey.*;
 
 @Slf4j
 @Component
@@ -30,58 +48,117 @@ public class LoadAssessmentReportInfoAdapter implements LoadAssessmentReportInfo
 
     private final AssessmentResultJpaRepository assessmentResultRepo;
     private final SubjectValueJpaRepository subjectValueRepo;
-    private final MaturityLevelPersistenceJpaAdapter maturityLevelJpaAdapter;
+    private final AssessmentKitJpaRepository assessmentKitJpaRepository;
+    private final ExpertGroupJpaRepository expertGroupJpaRepository;
+    private final MaturityLevelJpaRepository maturityLevelJpaRepository;
+    private final SubjectJpaRepository subjectJpaRepository;
+    private final QualityAttributeValueJpaRepository qualityAttributeValueJpaRepository;
+    private final AttributeJpaRepository attributeJpaRepository;
 
     @Override
-    public AssessmentResult load(UUID assessmentId) {
+    public AssessmentReport load(UUID assessmentId) {
         AssessmentResultJpaEntity assessmentResultEntity = assessmentResultRepo.findFirstByAssessment_IdOrderByLastModificationTimeDesc(assessmentId)
             .orElseThrow(() -> new ResourceNotFoundException(REPORT_ASSESSMENT_ASSESSMENT_RESULT_NOT_FOUND));
 
-        UUID assessmentResultId = assessmentResultEntity.getId();
+        AssessmentJpaEntity assessment = assessmentResultEntity.getAssessment();
+        AssessmentKitJpaEntity assessmentKitEntity = assessmentKitJpaRepository.findById(assessment.getAssessmentKitId())
+            .orElseThrow(() -> new ResourceNotFoundException(REPORT_ASSESSMENT_ASSESSMENT_KIT_NOT_FOUND));
+
+        ExpertGroupJpaEntity expertGroupEntity = expertGroupJpaRepository.findById(assessmentKitEntity.getExpertGroupId())
+            .orElseThrow(() -> new ResourceNotFoundException(REPORT_ASSESSMENT_EXPERT_GROUP_NOT_FOUND));
+
         long kitVersionId = assessmentResultEntity.getKitVersionId();
-        List<SubjectValueJpaEntity> subjectValueEntities = subjectValueRepo.findByAssessmentResultId(assessmentResultId);
+        List<MaturityLevelJpaEntity> maturityLevelEntities = maturityLevelJpaRepository.findAllByKitVersionId(kitVersionId);
 
-        Map<Long, MaturityLevel> maturityLevels = maturityLevelJpaAdapter.loadByKitVersionIdWithCompetences(kitVersionId)
-            .stream()
-            .collect(toMap(MaturityLevel::getId, x -> x));
-        List<SubjectValue> subjectValues = buildSubjectValues(subjectValueEntities, maturityLevels);
+        Map<Long, MaturityLevelJpaEntity> idToMaturityLevelEntities = maturityLevelEntities.stream()
+            .collect(toMap(MaturityLevelJpaEntity::getId, Function.identity()));
 
-        return new AssessmentResult(
-            assessmentResultId,
-            buildAssessment(assessmentResultEntity.getAssessment(), kitVersionId, maturityLevels),
-            kitVersionId,
-            subjectValues,
-            findMaturityLevelById(maturityLevels, assessmentResultEntity.getMaturityLevelId()),
+        AssessmentReport.AssessmentReportItem assessmentReportItem = new AssessmentReport.AssessmentReportItem(assessmentId,
+            assessment.getTitle(),
+            buildAssessmentKitItem(expertGroupEntity, assessmentKitEntity, maturityLevelEntities),
+            buildAssessmentMaturityLevel(assessmentResultEntity, idToMaturityLevelEntities),
             assessmentResultEntity.getConfidenceValue(),
             assessmentResultEntity.getIsCalculateValid(),
             assessmentResultEntity.getIsConfidenceValid(),
-            assessmentResultEntity.getLastModificationTime(),
-            assessmentResultEntity.getLastCalculationTime(),
-            assessmentResultEntity.getLastConfidenceCalculationTime());
+            AssessmentColor.valueOfById(assessment.getColorId()),
+            assessment.getLastModificationTime());
+
+        UUID assessmentResultId = assessmentResultEntity.getId();
+        List<AttributeReportItem> attributes = buildAttributeReportItems(assessmentResultId, idToMaturityLevelEntities);
+        List<MaturityLevel> maturityLevels = maturityLevelEntities.stream()
+            .map(e -> new MaturityLevel(e.getId(), e.getIndex(), e.getValue(), null))
+            .toList();
+        List<SubjectReportItem> subjects = buildSubjectReportItems(assessmentResultId, idToMaturityLevelEntities);
+
+        return new AssessmentReport(assessmentReportItem, attributes, maturityLevels, subjects);
     }
 
-    private List<SubjectValue> buildSubjectValues(List<SubjectValueJpaEntity> subjectValueEntities, Map<Long, MaturityLevel> maturityLevels) {
-        return subjectValueEntities.stream()
-            .map(x ->
-                new SubjectValue(
-                    x.getId(),
-                    new Subject(x.getSubjectId(), null, null),
-                    null,
-                    findMaturityLevelById(maturityLevels, x.getMaturityLevelId()),
-                    x.getConfidenceValue())
-            ).toList();
+    private static AssessmentKitItem buildAssessmentKitItem(ExpertGroupJpaEntity expertGroupEntity,
+                                                            AssessmentKitJpaEntity assessmentKitEntity,
+                                                            List<MaturityLevelJpaEntity> maturityLevelJpaEntities) {
+        ExpertGroup expertGroup =
+            new AssessmentReport.AssessmentReportItem.AssessmentKitItem.ExpertGroup(expertGroupEntity.getId(),
+                expertGroupEntity.getTitle());
+
+        return new AssessmentKitItem(assessmentKitEntity.getId(),
+            assessmentKitEntity.getTitle(),
+            assessmentKitEntity.getSummary(),
+            maturityLevelJpaEntities.size(),
+            expertGroup);
     }
 
-    private Assessment buildAssessment(AssessmentJpaEntity assessmentEntity, long kitVersionId, Map<Long, MaturityLevel> maturityLevels) {
-        AssessmentKit kit = new AssessmentKit(assessmentEntity.getAssessmentKitId(), kitVersionId, new ArrayList<>(maturityLevels.values()));
-        return mapToDomainModel(assessmentEntity, kit);
+    private static AssessmentMaturityLevel buildAssessmentMaturityLevel(AssessmentResultJpaEntity assessmentResultEntity,
+                                                                        Map<Long, MaturityLevelJpaEntity> idToMaturityLevelEntities) {
+
+        MaturityLevelJpaEntity maturityLevelEntity = idToMaturityLevelEntities.get(assessmentResultEntity.getMaturityLevelId());
+        return new AssessmentMaturityLevel(maturityLevelEntity.getId(),
+            maturityLevelEntity.getTitle(),
+            maturityLevelEntity.getValue(),
+            maturityLevelEntity.getIndex());
     }
 
-    private MaturityLevel findMaturityLevelById(Map<Long, MaturityLevel> maturityLevels, long id) {
-        if (!maturityLevels.containsKey(id)) {
-            log.error("No maturityLevel found with id={}", id);
-            throw new ResourceNotFoundException(REPORT_ASSESSMENT_MATURITY_LEVEL_NOT_FOUND);
-        }
-        return maturityLevels.get(id);
+    private List<AttributeReportItem> buildAttributeReportItems(UUID assessmentResultId,
+                                                                Map<Long, MaturityLevelJpaEntity> idToMaturityLevelEntities) {
+        List<QualityAttributeValueJpaEntity> attributeValueEntities = qualityAttributeValueJpaRepository.findByAssessmentResultId(assessmentResultId);
+        Set<UUID> attrRefNums = attributeValueEntities.stream()
+            .map(QualityAttributeValueJpaEntity::getAttributeRefNum)
+            .collect(Collectors.toSet());
+        Map<UUID, Long> attributeRefNumToMaturityLevelId = attributeValueEntities.stream()
+            .collect(toMap(QualityAttributeValueJpaEntity::getAttributeRefNum, QualityAttributeValueJpaEntity::getMaturityLevelId));
+        List<AttributeJpaEntity> attributeEntities = attributeJpaRepository.findAllByRefNumIn(attrRefNums);
+        return attributeEntities.stream()
+            .map(e -> {
+                Long maturityLevelId = attributeRefNumToMaturityLevelId.get(e.getRefNum());
+                Integer index = idToMaturityLevelEntities.get(maturityLevelId).getIndex();
+                return new AssessmentReport.AttributeReportItem(e.getId(), e.getTitle(), index);
+            })
+            .toList();
+    }
+
+    private List<SubjectReportItem> buildSubjectReportItems(UUID assessmentResultId,
+                                                            Map<Long, MaturityLevelJpaEntity> idToMaturityLevelEntities) {
+        List<SubjectValueJpaEntity> subjectValueEntities = subjectValueRepo.findByAssessmentResultId(assessmentResultId);
+        Set<UUID> refNums = subjectValueEntities.stream()
+            .map(SubjectValueJpaEntity::getSubjectRefNum)
+            .collect(Collectors.toSet());
+
+        Map<UUID, Long> subjectRefNumToMaturityLevelId = subjectValueEntities.stream()
+            .collect(toMap(SubjectValueJpaEntity::getSubjectRefNum, SubjectValueJpaEntity::getMaturityLevelId));
+
+        List<SubjectJpaEntity> subjectEntities = subjectJpaRepository.findAllByRefNumIn(refNums);
+
+        return subjectEntities.stream()
+            .map(e -> {
+                Long maturityLevelId = subjectRefNumToMaturityLevelId.get(e.getRefNum());
+                MaturityLevelJpaEntity maturityLevelEntity = idToMaturityLevelEntities.get(maturityLevelId);
+                SubjectMaturityLevel subjectMaturityLevel =
+                    new AssessmentReport.SubjectReportItem.SubjectMaturityLevel(maturityLevelEntity.getId(),
+                        maturityLevelEntity.getTitle());
+                return new AssessmentReport.SubjectReportItem(e.getId(),
+                    e.getTitle(),
+                    e.getIndex(),
+                    e.getDescription(),
+                    subjectMaturityLevel);
+            }).toList();
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/domain/report/AssessmentReport.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/domain/report/AssessmentReport.java
@@ -1,26 +1,57 @@
 package org.flickit.assessment.core.application.domain.report;
 
 import org.flickit.assessment.core.application.domain.AssessmentColor;
+import org.flickit.assessment.core.application.domain.MaturityLevel;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public record AssessmentReport(AssessmentReportItem assessment,
-                               List<TopAttribute> topStrengths,
-                               List<TopAttribute> topWeaknesses,
+                               List<AttributeReportItem> attributes,
+                               List<MaturityLevel> maturityLevels,
                                List<SubjectReportItem> subjects) {
 
     public record AssessmentReportItem(UUID id,
                                        String title,
-                                       Long maturityLevelId,
+                                       AssessmentKitItem assessmentKit,
+                                       AssessmentMaturityLevel maturityLevel,
                                        Double confidenceValue,
                                        boolean isCalculateValid,
                                        boolean isConfidenceValid,
                                        AssessmentColor color,
                                        LocalDateTime lastModificationTime) {
+        public record AssessmentKitItem(
+            Long id,
+            String title,
+            String summary,
+            Integer maturityLevelCount,
+            ExpertGroup expertGroup
+        ) {
+            public record ExpertGroup(Long id, String title) {}
+        }
+
+        public record AssessmentMaturityLevel(
+            Long id,
+            String title,
+            Integer value,
+            Integer index
+        ) {}
     }
 
-    public record SubjectReportItem(Long id, Long maturityLevelId) {
+    public record AttributeReportItem(
+        Long id,
+        String title,
+        int maturityLevelIndex
+    ) {}
+
+    public record SubjectReportItem(
+        Long id,
+        String title,
+        Integer index,
+        String description,
+        SubjectMaturityLevel maturityLevel
+    ) {
+        public record SubjectMaturityLevel(Long id, String title) {}
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/assessment/ReportAssessmentUseCase.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/in/assessment/ReportAssessmentUseCase.java
@@ -6,13 +6,15 @@ import lombok.Value;
 import org.flickit.assessment.common.application.SelfValidating;
 import org.flickit.assessment.core.application.domain.report.AssessmentReport;
 
+import java.util.List;
 import java.util.UUID;
 
+import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_ID_NOT_NULL;
 import static org.flickit.assessment.core.common.ErrorMessageKey.REPORT_ASSESSMENT_ID_NOT_NULL;
 
 public interface ReportAssessmentUseCase {
 
-    AssessmentReport reportAssessment(Param param);
+    Result reportAssessment(Param param);
 
     @Value
     @EqualsAndHashCode(callSuper = false)
@@ -21,9 +23,22 @@ public interface ReportAssessmentUseCase {
         @NotNull(message = REPORT_ASSESSMENT_ID_NOT_NULL)
         UUID assessmentId;
 
-        public Param(UUID assessmentId) {
+        @NotNull(message = COMMON_CURRENT_USER_ID_NOT_NULL)
+        UUID currentUserId;
+
+        public Param(UUID assessmentId, UUID currentUserId) {
             this.assessmentId = assessmentId;
+            this.currentUserId = currentUserId;
             this.validateSelf();
         }
+    }
+
+    record Result(
+        AssessmentReport.AssessmentReportItem assessment,
+        List<TopAttribute> topStrengths,
+        List<TopAttribute> topWeaknesses,
+        List<AssessmentReport.SubjectReportItem> subjects) {
+
+        public record TopAttribute(Long id, String title) {}
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/assessmentresult/LoadAssessmentReportInfoPort.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/port/out/assessmentresult/LoadAssessmentReportInfoPort.java
@@ -2,7 +2,7 @@ package org.flickit.assessment.core.application.port.out.assessmentresult;
 
 import org.flickit.assessment.common.exception.CalculateNotValidException;
 import org.flickit.assessment.common.exception.ResourceNotFoundException;
-import org.flickit.assessment.core.application.domain.AssessmentResult;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport;
 
 import java.util.UUID;
 
@@ -16,5 +16,5 @@ public interface LoadAssessmentReportInfoPort {
      * @throws ResourceNotFoundException  If the assessment result is not found.
      * @throws CalculateNotValidException If the assessment result is not valid.
      */
-    AssessmentResult load(UUID assessmentId);
+    AssessmentReport load(UUID assessmentId);
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/assessment/ReportAssessmentService.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/assessment/ReportAssessmentService.java
@@ -3,22 +3,22 @@ package org.flickit.assessment.core.application.service.assessment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.flickit.assessment.common.application.port.out.ValidateAssessmentResultPort;
-import org.flickit.assessment.core.application.domain.*;
+import org.flickit.assessment.common.exception.AccessDeniedException;
+import org.flickit.assessment.common.exception.ResourceNotFoundException;
 import org.flickit.assessment.core.application.domain.report.AssessmentReport;
-import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem;
-import org.flickit.assessment.core.application.domain.report.AssessmentReport.SubjectReportItem;
-import org.flickit.assessment.core.application.domain.report.TopAttributeResolver;
 import org.flickit.assessment.core.application.port.in.assessment.ReportAssessmentUseCase;
+import org.flickit.assessment.core.application.port.out.assessment.CheckAssessmentExistencePort;
+import org.flickit.assessment.core.application.port.out.assessment.CheckUserAssessmentAccessPort;
 import org.flickit.assessment.core.application.port.out.assessmentresult.LoadAssessmentReportInfoPort;
-import org.flickit.assessment.core.application.port.out.qualityattributevalue.LoadAttributeValueListPort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 
-import static java.util.stream.Collectors.toMap;
+import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_NOT_ALLOWED;
 import static org.flickit.assessment.core.application.domain.MaturityLevel.middleLevel;
+import static org.flickit.assessment.core.common.ErrorMessageKey.REPORT_ASSESSMENT_ASSESSMENT_ID_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -28,56 +28,41 @@ public class ReportAssessmentService implements ReportAssessmentUseCase {
 
     private final ValidateAssessmentResultPort validateAssessmentResultPort;
     private final LoadAssessmentReportInfoPort loadReportInfoPort;
-    private final LoadAttributeValueListPort loadAttributeValueListPort;
+    private final CheckAssessmentExistencePort checkAssessmentExistencePort;
+    private final CheckUserAssessmentAccessPort checkUserAssessmentAccessPort;
 
     @Override
-    public AssessmentReport reportAssessment(Param param) {
+    public Result reportAssessment(Param param) {
+        if (!checkAssessmentExistencePort.existsById(param.getAssessmentId()))
+            throw new ResourceNotFoundException(REPORT_ASSESSMENT_ASSESSMENT_ID_NOT_FOUND);
+
+        if (!checkUserAssessmentAccessPort.hasAccess(param.getAssessmentId(), param.getCurrentUserId()))
+            throw new AccessDeniedException(COMMON_CURRENT_USER_NOT_ALLOWED);
+
         validateAssessmentResultPort.validate(param.getAssessmentId());
 
-        var assessmentResult = loadReportInfoPort.load(param.getAssessmentId());
+        var assessmentReport = loadReportInfoPort.load(param.getAssessmentId());
+        var midLevelMaturity = middleLevel(assessmentReport.maturityLevels());
+        List<AssessmentReport.AttributeReportItem> attributes = assessmentReport.attributes();
+        List<Result.TopAttribute> topStrengths = attributes.stream()
+            .sorted(Comparator.comparing(AssessmentReport.AttributeReportItem::maturityLevelIndex, Comparator.reverseOrder()))
+            .filter(e -> midLevelMaturity.getIndex() <= e.maturityLevelIndex())
+            .limit(3)
+            .map(e -> new Result.TopAttribute(e.id(), e.title()))
+            .toList();
 
-        AssessmentKit kit = assessmentResult.getAssessment().getAssessmentKit();
-        var maturityLevels = kit.getMaturityLevels();
-        Map<Long, MaturityLevel> maturityLevelsMap = maturityLevels.stream()
-            .collect(toMap(MaturityLevel::getId, x -> x));
-
-        var attributeValues = loadAttributeValueListPort.loadAll(assessmentResult.getId(), maturityLevelsMap);
-
-        var assessmentReportItem = buildAssessment(assessmentResult);
-        var subjectReportItems = buildSubjects(assessmentResult);
-
-        var midLevelMaturity = middleLevel(maturityLevels);
-        TopAttributeResolver topAttributeResolver = new TopAttributeResolver(attributeValues, midLevelMaturity);
-        var topStrengths = topAttributeResolver.getTopStrengths();
-        var topWeaknesses = topAttributeResolver.getTopWeaknesses();
+        List<Result.TopAttribute> topWeaknesses = attributes.stream()
+            .sorted(Comparator.comparing(AssessmentReport.AttributeReportItem::maturityLevelIndex))
+            .filter(e -> e.maturityLevelIndex() <= midLevelMaturity.getIndex())
+            .limit(3)
+            .map(e -> new Result.TopAttribute(e.id(), e.title()))
+            .toList();
 
         log.debug("AssessmentReport returned for assessmentId=[{}].", param.getAssessmentId());
 
-        return new AssessmentReport(
-            assessmentReportItem,
+        return new Result(assessmentReport.assessment(),
             topStrengths,
             topWeaknesses,
-            subjectReportItems);
-    }
-
-    private AssessmentReportItem buildAssessment(AssessmentResult assessmentResult) {
-        Assessment assessment = assessmentResult.getAssessment();
-        return new AssessmentReport.AssessmentReportItem(
-            assessment.getId(),
-            assessment.getTitle(),
-            assessmentResult.getMaturityLevel().getId(),
-            assessmentResult.getConfidenceValue(),
-            true,
-            true,
-            AssessmentColor.valueOfById(assessment.getColorId()),
-            assessment.getLastModificationTime()
-        );
-    }
-
-    private List<SubjectReportItem> buildSubjects(AssessmentResult assessmentResult) {
-        return assessmentResult.getSubjectValues()
-            .stream()
-            .map(x -> new SubjectReportItem(x.getSubject().getId(), x.getMaturityLevel().getId()))
-            .toList();
+            assessmentReport.subjects());
     }
 }

--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/common/ErrorMessageKey.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/common/ErrorMessageKey.java
@@ -73,9 +73,11 @@ public class ErrorMessageKey {
     public static final String GET_EVIDENCE_LIST_SIZE_MAX = "get-evidence-list.size.max";
     public static final String GET_EVIDENCE_LIST_PAGE_MIN = "get-evidence-list.page.min";
 
+    public static final String REPORT_ASSESSMENT_ASSESSMENT_ID_NOT_FOUND = "report-assessment-assessment.id.notFound";
     public static final String REPORT_ASSESSMENT_ID_NOT_NULL = "report-assessment.assessment.id.notNull";
     public static final String REPORT_ASSESSMENT_ASSESSMENT_RESULT_NOT_FOUND = "report-assessment.assessmentResult.notFound";
-    public static final String REPORT_ASSESSMENT_MATURITY_LEVEL_NOT_FOUND = "report-assessment.maturityLevelId.notFound";
+    public static final String REPORT_ASSESSMENT_ASSESSMENT_KIT_NOT_FOUND = "report-assessment.assessmentKit.notFound";
+    public static final String REPORT_ASSESSMENT_EXPERT_GROUP_NOT_FOUND = "report-assessment.expertGroup.notFound";
 
     public static final String GET_ASSESSMENT_PROGRESS_ASSESSMENT_ID_NOT_NULL = "get-assessment-progress.assessment.id.notNull";
     public static final String GET_ASSESSMENT_PROGRESS_ASSESSMENT_RESULT_NOT_FOUND = "get-assessment-progress.assessmentResult.notFound";

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/assessment/ReportAssessmentServiceTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/assessment/ReportAssessmentServiceTest.java
@@ -1,29 +1,34 @@
 package org.flickit.assessment.core.application.service.assessment;
 
+import org.flickit.assessment.common.exception.AccessDeniedException;
+import org.flickit.assessment.common.exception.ResourceNotFoundException;
 import org.flickit.assessment.core.application.domain.*;
 import org.flickit.assessment.core.application.domain.report.AssessmentReport;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AttributeReportItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.SubjectReportItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.SubjectReportItem.SubjectMaturityLevel;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem.AssessmentKitItem;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem.AssessmentMaturityLevel;
+import org.flickit.assessment.core.application.domain.report.AssessmentReport.AssessmentReportItem.AssessmentKitItem.ExpertGroup;
 import org.flickit.assessment.core.application.internal.ValidateAssessmentResult;
 import org.flickit.assessment.core.application.port.in.assessment.ReportAssessmentUseCase;
+import org.flickit.assessment.core.application.port.out.assessment.CheckAssessmentExistencePort;
+import org.flickit.assessment.core.application.port.out.assessment.CheckUserAssessmentAccessPort;
 import org.flickit.assessment.core.application.port.out.assessmentresult.LoadAssessmentReportInfoPort;
-import org.flickit.assessment.core.application.port.out.qualityattributevalue.LoadAttributeValueListPort;
-import org.flickit.assessment.core.test.fixture.application.MaturityLevelMother;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
+import java.util.UUID;
 
-import static java.util.stream.Collectors.toMap;
-import static org.flickit.assessment.core.test.fixture.application.AssessmentResultMother.validResultWithSubjectValuesAndMaturityLevel;
-import static org.flickit.assessment.core.test.fixture.application.MaturityLevelMother.*;
-import static org.flickit.assessment.core.test.fixture.application.QualityAttributeMother.simpleAttribute;
-import static org.flickit.assessment.core.test.fixture.application.QualityAttributeValueMother.withAttributeAndMaturityLevel;
-import static org.flickit.assessment.core.test.fixture.application.SubjectValueMother.withQAValuesAndMaturityLevel;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -40,47 +45,101 @@ class ReportAssessmentServiceTest {
     private LoadAssessmentReportInfoPort loadReportInfoPort;
 
     @Mock
-    private LoadAttributeValueListPort loadAttributeValueListPort;
+    private CheckAssessmentExistencePort checkAssessmentExistencePort;
+
+    @Mock
+    private CheckUserAssessmentAccessPort checkUserAssessmentAccessPort;
 
     @Test
     void testReportAssessment_ValidResult() {
-        List<QualityAttributeValue> qaValues = List.of(
-            withAttributeAndMaturityLevel(simpleAttribute(), levelOne()),
-            withAttributeAndMaturityLevel(simpleAttribute(), levelTwo()),
-            withAttributeAndMaturityLevel(simpleAttribute(), levelThree()),
-            withAttributeAndMaturityLevel(simpleAttribute(), levelFour()),
-            withAttributeAndMaturityLevel(simpleAttribute(), levelFive())
-        );
-        SubjectValue subjectValue = withQAValuesAndMaturityLevel(qaValues, MaturityLevelMother.levelThree());
-        AssessmentResult assessmentResult = validResultWithSubjectValuesAndMaturityLevel(
-            List.of(subjectValue), levelTwo());
+        UUID currentUserId = UUID.randomUUID();
+        UUID assessmentId = UUID.randomUUID();
 
-        AssessmentKit kit = assessmentResult.getAssessment().getAssessmentKit();
-        Map<Long, MaturityLevel> maturityLevels = kit.getMaturityLevels()
-            .stream()
-            .collect(toMap(MaturityLevel::getId, x -> x));
-        ReportAssessmentUseCase.Param param = new ReportAssessmentUseCase.Param(assessmentResult.getAssessment().getId());
+        ReportAssessmentUseCase.Param param = new ReportAssessmentUseCase.Param(assessmentId, currentUserId);
 
-        when(loadReportInfoPort.load(assessmentResult.getAssessment().getId())).thenReturn(assessmentResult);
-        when(loadAttributeValueListPort.loadAll(assessmentResult.getId(), maturityLevels)).thenReturn(qaValues);
+        List<AttributeReportItem> attributes = List.of(new AttributeReportItem(1L, "attrTitle1", 1),
+            new AttributeReportItem(2L, "attrTitle2", 2),
+            new AttributeReportItem(3L, "attrTitle3", 3));
+        ExpertGroup expertGroup = new ExpertGroup(1L, "expertGroupTitle1");
+        AssessmentKitItem kit = new AssessmentKitItem(1L, "kitTitle", "kitSummary", 3, expertGroup);
+        AssessmentMaturityLevel assessmentMaturityLevel = new AssessmentMaturityLevel(1L, "good", 1, 2);
+        LocalDateTime lastModificationTime = LocalDateTime.now();
+        AssessmentReportItem assessment = new AssessmentReportItem(assessmentId,
+            "assessmentTitle",
+            kit,
+            assessmentMaturityLevel,
+            1.5,
+            true,
+            true,
+            AssessmentColor.BLUE,
+            lastModificationTime);
 
-        doNothing().when(validateAssessmentResult).validate(assessmentResult.getAssessment().getId());
+        List<MaturityLevel> maturityLevels = List.of(new MaturityLevel(1L, 1, 1, null),
+            new MaturityLevel(2L, 2, 1, null),
+            new MaturityLevel(3L, 3, 2, null),
+            new MaturityLevel(4L, 4, 1, null),
+            new MaturityLevel(5L, 5, 2, null));
+        SubjectMaturityLevel softwareLevel = new SubjectMaturityLevel(1L, "good");
+        SubjectMaturityLevel teamLevel = new SubjectMaturityLevel(2L, "weak");
+        List<SubjectReportItem> subjects = List.of(new SubjectReportItem(1L, "software", 1, "subjectDesc1", softwareLevel),
+            new SubjectReportItem(2L, "team", 2, "subjectDesc2", teamLevel));
+        AssessmentReport assessmentReport = new AssessmentReport(assessment, attributes, maturityLevels, subjects);
 
-        AssessmentReport assessmentReport = service.reportAssessment(param);
+        when(checkAssessmentExistencePort.existsById(param.getAssessmentId())).thenReturn(true);
+        when(checkUserAssessmentAccessPort.hasAccess(assessmentId, currentUserId)).thenReturn(true);
+        doNothing().when(validateAssessmentResult).validate(param.getAssessmentId());
+        when(loadReportInfoPort.load(assessmentId)).thenReturn(assessmentReport);
+
+        ReportAssessmentUseCase.Result result = service.reportAssessment(param);
 
         assertNotNull(assessmentReport);
         assertNotNull(assessmentReport.assessment());
-        assertEquals(assessmentResult.getAssessment().getId(), assessmentReport.assessment().id());
-        assertEquals(assessmentResult.getAssessment().getTitle(), assessmentReport.assessment().title());
-        assertEquals(assessmentResult.getMaturityLevel().getId(), assessmentReport.assessment().maturityLevelId());
-        assertEquals(assessmentResult.getAssessment().getColorId(), assessmentReport.assessment().color().getId());
-        assertEquals(assessmentResult.getIsCalculateValid(), assessmentReport.assessment().isCalculateValid());
-        assertEquals(assessmentResult.getAssessment().getLastModificationTime(), assessmentReport.assessment().lastModificationTime());
+        assertEquals(assessmentReport.assessment().id(), result.assessment().id());
+        assertEquals(assessmentReport.assessment().title(), result.assessment().title());
+        assertEquals(assessmentReport.assessment().confidenceValue(), result.assessment().confidenceValue());
+        assertEquals(assessmentReport.assessment().isCalculateValid(), result.assessment().isCalculateValid());
+        assertEquals(assessmentReport.assessment().isConfidenceValid(), result.assessment().isConfidenceValid());
+        assertEquals(assessmentReport.assessment().lastModificationTime(), result.assessment().lastModificationTime());
+        assertEquals(assessmentReport.assessment().color(), result.assessment().color());
+        assertEquals(assessmentReport.assessment().maturityLevel().id(), result.assessment().maturityLevel().id());
+        assertEquals(assessmentReport.assessment().maturityLevel().index(), result.assessment().maturityLevel().index());
+        assertEquals(assessmentReport.assessment().maturityLevel().title(), result.assessment().maturityLevel().title());
+        assertEquals(assessmentReport.assessment().maturityLevel().value(), result.assessment().maturityLevel().value());
+        assertEquals(assessmentReport.assessment().assessmentKit().id(), result.assessment().assessmentKit().id());
+        assertEquals(assessmentReport.assessment().assessmentKit().title(), result.assessment().assessmentKit().title());
+        assertEquals(assessmentReport.assessment().assessmentKit().summary(), result.assessment().assessmentKit().summary());
+        assertEquals(assessmentReport.assessment().assessmentKit().maturityLevelCount(), result.assessment().assessmentKit().maturityLevelCount());
+        assertEquals(assessmentReport.assessment().assessmentKit().expertGroup().id(), result.assessment().assessmentKit().expertGroup().id());
+        assertEquals(assessmentReport.assessment().assessmentKit().expertGroup().title(), result.assessment().assessmentKit().expertGroup().title());
 
-        assertNotNull(assessmentReport.topStrengths());
-        assertEquals(3, assessmentReport.topStrengths().size());
+        assertNotNull(result.topStrengths());
+        assertEquals(1, result.topStrengths().size());
+        assertNotNull(result.topWeaknesses());
+        assertEquals(3, result.topWeaknesses().size());
 
-        assertNotNull(assessmentReport.topWeaknesses());
-        assertEquals(2, assessmentReport.topWeaknesses().size());
+        assertEquals(assessmentReport.subjects().size(), result.subjects().size());
+    }
+
+    @Test
+    void testReportAssessment_AssessmentDoesNotExist_ThrowException() {
+        UUID currentUserId = UUID.randomUUID();
+        UUID assessmentId = UUID.randomUUID();
+        ReportAssessmentUseCase.Param param = new ReportAssessmentUseCase.Param(assessmentId, currentUserId);
+
+        when(checkAssessmentExistencePort.existsById(param.getAssessmentId())).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> service.reportAssessment(param));
+    }
+
+    @Test
+    void testReportAssessment_CurrentUserHasNotAccess_ThrowException() {
+        UUID currentUserId = UUID.randomUUID();
+        UUID assessmentId = UUID.randomUUID();
+        ReportAssessmentUseCase.Param param = new ReportAssessmentUseCase.Param(assessmentId, currentUserId);
+
+        when(checkAssessmentExistencePort.existsById(param.getAssessmentId())).thenReturn(true);
+        when(checkUserAssessmentAccessPort.hasAccess(assessmentId, currentUserId)).thenReturn(false);
+
+        assertThrows(AccessDeniedException.class, () -> service.reportAssessment(param));
     }
 }

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/attribute/AttributeJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/attribute/AttributeJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public interface AttributeJpaRepository extends JpaRepository<AttributeJpaEntity, Long> {
@@ -66,6 +67,8 @@ public interface AttributeJpaRepository extends JpaRepository<AttributeJpaEntity
         WHERE a.id = :attributeId
         """)
     UUID findRefNumById(@Param("attributeId") Long attributeId);
+
+    List<AttributeJpaEntity> findAllByRefNumIn(Set<UUID> refNums);
 
     AttributeJpaEntity findByKitVersionIdAndRefNum(Long kitVersionId, UUID refNum);
 

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/subject/SubjectJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/subject/SubjectJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface SubjectJpaRepository extends JpaRepository<SubjectJpaEntity, Long> {
@@ -54,4 +55,6 @@ public interface SubjectJpaRepository extends JpaRepository<SubjectJpaEntity, Lo
             WHERE s.id = :subjectId
         """)
     UUID findRefNumById(@Param(value = "subjectId") Long subjectId);
+
+    List<SubjectJpaEntity> findAllByRefNumIn(Set<UUID> refNum);
 }


### PR DESCRIPTION
Instead of returning ids of required entities, the entities themselves have returned in the output of service. The existence of assessment is checked, And access of the current user to assessment is checked too.