### PR TITLE
FAC-325 Change  baseinfo_assessmentkittag table

### DIFF
--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/kittag/KitTagJpaEntity.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/kittag/KitTagJpaEntity.java
@@ -1,0 +1,27 @@
+package org.flickit.assessment.data.jpa.kit.kittag;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "fak_kit_tag")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class KitTagJpaEntity {
+
+    @Id
+    @EqualsAndHashCode.Include
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fak_kit_tag_id_seq")
+    @SequenceGenerator(name = "fak_kit_tag_id_seq", sequenceName = "fak_kit_tag_id_seq", allocationSize = 1)
+    @Column(name = "id", updatable = false, nullable = false)
+    private Long id;
+
+    @Column(name = "title", nullable = false, unique = true)
+    private String title;
+
+    @Column(name = "code", nullable = false, unique = true)
+    private String code;
+}

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/kittag/KitTagJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/kittag/KitTagJpaRepository.java
@@ -1,0 +1,6 @@
+package org.flickit.assessment.data.jpa.kit.kittag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KitTagJpaRepository extends JpaRepository<KitTagJpaEntity, Long> {
+}

--- a/flickit-assessment-data/src/main/resources/liquibase/changelog-0.17.xml
+++ b/flickit-assessment-data/src/main/resources/liquibase/changelog-0.17.xml
@@ -47,4 +47,33 @@
                                  deferrable="true" initiallyDeferred="true" onDelete="CASCADE"
                                  validate="true"/>
     </changeSet>
+
+    <changeSet id="0.17-08" author="Ali Sedaghat">
+        <renameTable oldTableName="baseinfo_assessmentkittag" newTableName="fak_kit_tag"/>
+    </changeSet>
+
+    <changeSet id="0.17-09" author="Ali Sedaghat">
+        <sql>alter table fak_kit_tag rename constraint baseinfo_profiletag_pkey to pk_fak_kit_tag;</sql>
+    </changeSet>
+
+    <changeSet id="0.17-10" author="Ali Sedaghat">
+        <dropUniqueConstraint constraintName="baseinfo_profiletag_code_4987a4c6_uniq" tableName="fak_kit_tag"/>
+    </changeSet>
+
+    <changeSet id="0.17-11" author="Ali Sedaghat">
+        <dropUniqueConstraint constraintName="baseinfo_profiletag_title_b2cd9f8a_uniq" tableName="fak_kit_tag"/>
+    </changeSet>
+
+    <changeSet id="0.17-12" author="Ali Sedaghat">
+        <addUniqueConstraint tableName="fak_kit_tag" columnNames="code" constraintName="uq_fak_kittag_code"/>
+    </changeSet>
+
+    <changeSet id="0.17-13" author="Ali Sedaghat">
+        <addUniqueConstraint tableName="fak_kit_tag" columnNames="title" constraintName="uq_fak_kittag_title"/>
+    </changeSet>
+
+    <changeSet id="0.17-14" author="Ali Sedaghat">
+        <renameSequence oldSequenceName="baseinfo_profiletag_id_seq" newSequenceName="fak_kit_tag_id_seq"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Name of baseinfo_assessmentkittag has changed to fak_kit_tag, the sequence and constraint names have changed too. The corresponding jpa entity which named KitTagJpaEntity, and also its repository interface has added too.