### PR TITLE
FAC-320 Implement get questionnaire details use case

### DIFF
--- a/flickit-assessment-common/src/main/resources/i18n/kit/messages_en.properties
+++ b/flickit-assessment-common/src/main/resources/i18n/kit/messages_en.properties
@@ -37,6 +37,10 @@ get-kit-user-list.size.max='size' must be less than or equal to 100
 get-kit-minimal-info.kitId.notNull='kitId' may not be empty
 get-kit-minimal-info.kitId.notFound=AssessmentKit with the given id does not exist
 
+get-questionnaire.kitId.notNull='kitId' may not be empty
+get-questionnaire.questionnaireId.notNull='questionnaireId' may not be empty
+get-questionnaire.questionnaireId.notFound=no questionnaire found by this 'questionnaireId' and 'kitId'
+
 get-kit-dsl-download-link.kitId.notNull='kitId' may not be empty
 get-kit-dsl-download-link.dslFile.notFound=DSL file not found
 get-kit-dsl-download-link.filePath.notFound='filePath' not found

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/question/QuestionJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/question/QuestionJpaRepository.java
@@ -128,4 +128,6 @@ public interface QuestionJpaRepository extends JpaRepository<QuestionJpaEntity, 
             ) GROUP BY qn.id order by qn.id
     """)
     List<FirstUnansweredQuestionView> findQuestionnairesFirstUnansweredQuestion(@Param("assessmentResultId") UUID assessmentResultId);
+
+    List<QuestionJpaEntity> findAllByQuestionnaireIdOrderByIndexAsc(Long questionnaireId);
 }

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/questionnaire/QuestionnaireJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/questionnaire/QuestionnaireJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface QuestionnaireJpaRepository extends JpaRepository<QuestionnaireJpaEntity, Long> {
@@ -31,4 +32,13 @@ public interface QuestionnaireJpaRepository extends JpaRepository<QuestionnaireJ
         @Param(value = "lastModificationTime") LocalDateTime lastModificationTime,
         @Param(value = "lastModifiedBy") UUID lastModifiedBy
     );
+
+    @Query("""
+        SELECT qn
+        FROM AssessmentKitJpaEntity k
+            JOIN KitVersionJpaEntity kv ON k.id = kv.kit.id
+            JOIN QuestionnaireJpaEntity qn ON qn.kitVersionId = kv.id
+        WHERE qn.id = :questionnaireId AND k.id = :kitId
+    """)
+    Optional<QuestionnaireJpaEntity> findQuestionnaireByIdAndKitId(Long questionnaireId, Long kitId);
 }

--- a/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/subject/SubjectJpaRepository.java
+++ b/flickit-assessment-data/src/main/java/org/flickit/assessment/data/jpa/kit/subject/SubjectJpaRepository.java
@@ -54,4 +54,11 @@ public interface SubjectJpaRepository extends JpaRepository<SubjectJpaEntity, Lo
             WHERE s.id = :subjectId
         """)
     UUID findRefNumById(@Param(value = "subjectId") Long subjectId);
+
+    @Query("""
+        SELECT s
+        FROM SubjectJpaEntity s JOIN SubjectQuestionnaireJpaEntity sq ON s.id = sq.subjectId
+        WHERE sq.questionnaireId = :questionnaireId
+    """)
+    List<SubjectJpaEntity> findAllByQuestionnaireId(Long questionnaireId);
 }

--- a/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/adapter/in/rest/questionnaire/GetQuestionnaireResponseDto.java
+++ b/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/adapter/in/rest/questionnaire/GetQuestionnaireResponseDto.java
@@ -1,0 +1,12 @@
+package org.flickit.assessment.kit.adapter.in.rest.questionnaire;
+
+import org.flickit.assessment.kit.application.port.out.questionnaire.LoadQuestionnairePort;
+
+import java.util.List;
+
+public record GetQuestionnaireResponseDto(
+    int questionsCount,
+    List<String> relatedSubjects,
+    String description,
+    List<LoadQuestionnairePort.Result.Question> questions
+) {}

--- a/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/adapter/in/rest/questionnaire/GetQuestionnaireRestController.java
+++ b/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/adapter/in/rest/questionnaire/GetQuestionnaireRestController.java
@@ -1,0 +1,41 @@
+package org.flickit.assessment.kit.adapter.in.rest.questionnaire;
+
+import lombok.RequiredArgsConstructor;
+import org.flickit.assessment.common.config.jwt.UserContext;
+import org.flickit.assessment.kit.application.port.in.questionnaire.GetQuestionnaireUseCase;
+import org.flickit.assessment.kit.application.port.out.questionnaire.LoadQuestionnairePort.Result;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class GetQuestionnaireRestController {
+
+    private final GetQuestionnaireUseCase useCase;
+    private final UserContext userContext;
+
+    @GetMapping("/assessment-kits/{kitId}/details/questionnaires/{questionnaireId}")
+    public ResponseEntity<GetQuestionnaireResponseDto> getQuestionnaire(@PathVariable("kitId") Long kitId,
+                                                                        @PathVariable("questionnaireId") Long questionnaireId) {
+        UUID currentUserId = userContext.getUser().id();
+        var response = useCase.getQuestionnaire(toParam(kitId, questionnaireId, currentUserId));
+        GetQuestionnaireResponseDto responseDto = toResponseDto(response);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    private GetQuestionnaireResponseDto toResponseDto(Result result) {
+        return new GetQuestionnaireResponseDto(result.questionsCount(),
+            result.relatedSubjects(),
+            result.description(),
+            result.questions());
+    }
+
+    private GetQuestionnaireUseCase.Param toParam(Long kitId, Long questionnaireId, UUID currentUserId) {
+        return new GetQuestionnaireUseCase.Param(kitId, questionnaireId, currentUserId);
+    }
+}

--- a/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/adapter/out/persistence/questionnaire/QuestionnairePersistenceJpaAdapter.java
+++ b/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/adapter/out/persistence/questionnaire/QuestionnairePersistenceJpaAdapter.java
@@ -1,21 +1,34 @@
 package org.flickit.assessment.kit.adapter.out.persistence.questionnaire;
 
 import lombok.RequiredArgsConstructor;
+import org.flickit.assessment.common.exception.ResourceNotFoundException;
+import org.flickit.assessment.data.jpa.kit.question.QuestionJpaEntity;
+import org.flickit.assessment.data.jpa.kit.question.QuestionJpaRepository;
+import org.flickit.assessment.data.jpa.kit.questionnaire.QuestionnaireJpaEntity;
 import org.flickit.assessment.data.jpa.kit.questionnaire.QuestionnaireJpaRepository;
+import org.flickit.assessment.data.jpa.kit.subject.SubjectJpaEntity;
+import org.flickit.assessment.data.jpa.kit.subject.SubjectJpaRepository;
 import org.flickit.assessment.kit.application.domain.Questionnaire;
 import org.flickit.assessment.kit.application.port.out.questionnaire.CreateQuestionnairePort;
+import org.flickit.assessment.kit.application.port.out.questionnaire.LoadQuestionnairePort;
 import org.flickit.assessment.kit.application.port.out.questionnaire.UpdateQuestionnairePort;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.UUID;
+
+import static org.flickit.assessment.kit.common.ErrorMessageKey.GET_QUESTIONNAIRE_QUESTIONNAIRE_ID_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
 public class QuestionnairePersistenceJpaAdapter implements
     CreateQuestionnairePort,
-    UpdateQuestionnairePort {
+    UpdateQuestionnairePort,
+    LoadQuestionnairePort {
 
     private final QuestionnaireJpaRepository repository;
+    private final QuestionJpaRepository questionRepository;
+    private final SubjectJpaRepository subjectRepository;
 
     @Override
     public Long persist(Questionnaire questionnaire, long kitVersionId, UUID createdBy) {
@@ -30,5 +43,23 @@ public class QuestionnairePersistenceJpaAdapter implements
             param.description(),
             param.lastModificationTime(),
             param.lastModifiedBy());
+    }
+
+    @Override
+    public Result loadQuestionnaire(Long questionnaireId, Long kitId) {
+        QuestionnaireJpaEntity questionnaireEntity = repository.findQuestionnaireByIdAndKitId(questionnaireId, kitId)
+            .orElseThrow(() -> new ResourceNotFoundException(GET_QUESTIONNAIRE_QUESTIONNAIRE_ID_NOT_FOUND));
+        List<QuestionJpaEntity> questionEntities = questionRepository.findAllByQuestionnaireIdOrderByIndexAsc(questionnaireId);
+        List<SubjectJpaEntity> subjectEntities = subjectRepository.findAllByQuestionnaireId(questionnaireId);
+
+        List<String> relatedSubjects = subjectEntities.stream()
+            .map(SubjectJpaEntity::getTitle)
+            .toList();
+
+        List<Result.Question> questions = questionEntities.stream()
+            .map(e -> new Result.Question(e.getId(), e.getTitle(), e.getIndex(), e.getMayNotBeApplicable()))
+            .toList();
+
+        return new Result(questionEntities.size(), relatedSubjects, questionnaireEntity.getDescription(), questions);
     }
 }

--- a/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/application/port/in/questionnaire/GetQuestionnaireUseCase.java
+++ b/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/application/port/in/questionnaire/GetQuestionnaireUseCase.java
@@ -1,0 +1,39 @@
+package org.flickit.assessment.kit.application.port.in.questionnaire;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.flickit.assessment.common.application.SelfValidating;
+import org.flickit.assessment.kit.application.port.in.assessmentkit.GetKitMinimalInfoUseCase;
+import org.flickit.assessment.kit.application.port.out.questionnaire.LoadQuestionnairePort.Result;
+
+import java.util.UUID;
+
+import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_ID_NOT_NULL;
+import static org.flickit.assessment.kit.common.ErrorMessageKey.*;
+
+public interface GetQuestionnaireUseCase {
+
+    Result getQuestionnaire(Param param);
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    class Param extends SelfValidating<GetKitMinimalInfoUseCase.Param> {
+
+        @NotNull(message = GET_QUESTIONNAIRE_KIT_ID_NOT_NULL)
+        Long kitId;
+
+        @NotNull(message = GET_QUESTIONNAIRE_QUESTIONNAIRE_ID_NOT_NULL)
+        Long questionnaireId;
+
+        @NotNull(message = COMMON_CURRENT_USER_ID_NOT_NULL)
+        UUID currentUserId;
+
+        public Param(Long kitId, Long questionnaireId, UUID currentUserId) {
+            this.kitId = kitId;
+            this.questionnaireId = questionnaireId;
+            this.currentUserId = currentUserId;
+            this.validateSelf();
+        }
+    }
+}

--- a/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/application/port/out/questionnaire/LoadQuestionnairePort.java
+++ b/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/application/port/out/questionnaire/LoadQuestionnairePort.java
@@ -1,0 +1,12 @@
+package org.flickit.assessment.kit.application.port.out.questionnaire;
+
+import java.util.List;
+
+public interface LoadQuestionnairePort {
+
+    Result loadQuestionnaire(Long questionnaireId, Long kitId);
+
+    record Result(int questionsCount, List<String> relatedSubjects, String description, List<Question> questions) {
+        public record Question(Long id, String title, Integer index, Boolean mayNotBeApplicable) {}
+    }
+}

--- a/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/application/service/questionnaire/GetQuestionnaireService.java
+++ b/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/application/service/questionnaire/GetQuestionnaireService.java
@@ -1,0 +1,32 @@
+package org.flickit.assessment.kit.application.service.questionnaire;
+
+import lombok.RequiredArgsConstructor;
+import org.flickit.assessment.common.exception.AccessDeniedException;
+import org.flickit.assessment.kit.application.port.in.questionnaire.GetQuestionnaireUseCase;
+import org.flickit.assessment.kit.application.port.out.assessmentkit.LoadKitExpertGroupPort;
+import org.flickit.assessment.kit.application.port.out.expertgroupaccess.CheckExpertGroupAccessPort;
+import org.flickit.assessment.kit.application.port.out.questionnaire.LoadQuestionnairePort;
+import org.flickit.assessment.kit.application.port.out.questionnaire.LoadQuestionnairePort.Result;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_NOT_ALLOWED;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetQuestionnaireService implements GetQuestionnaireUseCase {
+
+    private final LoadQuestionnairePort port;
+    private final CheckExpertGroupAccessPort checkExpertGroupAccessPort;
+    private final LoadKitExpertGroupPort loadKitExpertGroupPort;
+
+    @Override
+    public Result getQuestionnaire(Param param) {
+        Long expertGroupId = loadKitExpertGroupPort.loadKitExpertGroupId(param.getKitId());
+        if (!checkExpertGroupAccessPort.checkIsMember(expertGroupId, param.getCurrentUserId())) {
+            throw new AccessDeniedException(COMMON_CURRENT_USER_NOT_ALLOWED);
+        }
+        return port.loadQuestionnaire(param.getQuestionnaireId(), param.getKitId());
+    }
+}

--- a/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/common/ErrorMessageKey.java
+++ b/flickit-assessment-kit/src/main/java/org/flickit/assessment/kit/common/ErrorMessageKey.java
@@ -37,6 +37,10 @@ public class ErrorMessageKey {
     public static final String GET_KIT_MINIMAL_INFO_KIT_ID_NOT_NULL = "get-kit-minimal-info.kitId.notNull";
     public static final String GET_KIT_MINIMAL_INFO_KIT_ID_NOT_FOUND = "get-kit-minimal-info.kitId.notFound";
 
+    public static final String GET_QUESTIONNAIRE_KIT_ID_NOT_NULL = "get-questionnaire.kitId.notNull";
+    public static final String GET_QUESTIONNAIRE_QUESTIONNAIRE_ID_NOT_NULL = "get-questionnaire.questionnaireId.notNull";
+    public static final String GET_QUESTIONNAIRE_QUESTIONNAIRE_ID_NOT_FOUND = "get-questionnaire.questionnaireId.notFound";
+
     public static final String DELETE_KIT_USER_ACCESS_KIT_ID_NOT_NULL = "delete-kit-user-access.kitId.notNull";
     public static final String DELETE_KIT_USER_ACCESS_USER_ID_NOT_NULL = "delete-kit-user-access.userId.notNull";
     public static final String DELETE_KIT_USER_ACCESS_KIT_USER_NOT_FOUND = "delete-kit-user-access.kit-user.notFound";

--- a/flickit-assessment-kit/src/test/java/org/flickit/assessment/kit/application/service/questionnaire/GetQuestionnaireServiceTest.java
+++ b/flickit-assessment-kit/src/test/java/org/flickit/assessment/kit/application/service/questionnaire/GetQuestionnaireServiceTest.java
@@ -1,0 +1,76 @@
+package org.flickit.assessment.kit.application.service.questionnaire;
+
+import org.flickit.assessment.common.exception.AccessDeniedException;
+import org.flickit.assessment.kit.application.port.in.questionnaire.GetQuestionnaireUseCase;
+import org.flickit.assessment.kit.application.port.out.assessmentkit.LoadKitExpertGroupPort;
+import org.flickit.assessment.kit.application.port.out.expertgroupaccess.CheckExpertGroupAccessPort;
+import org.flickit.assessment.kit.application.port.out.questionnaire.LoadQuestionnairePort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetQuestionnaireServiceTest {
+
+    @InjectMocks
+    private GetQuestionnaireService getQuestionnaireService;
+
+    @Mock
+    private LoadQuestionnairePort loadQuestionnairePort;
+
+    @Mock
+    private CheckExpertGroupAccessPort checkExpertGroupAccessPort;
+
+    @Mock
+    private LoadKitExpertGroupPort loadKitExpertGroupPort;
+
+    @Test
+    void testGetQuestionnaire_ValidInput_ValidResult() {
+        Long kitId = 1L;
+        Long questionnaireId = 2L;
+        long expertGroupId = 3L;
+        UUID currentUserId = UUID.randomUUID();
+
+        GetQuestionnaireUseCase.Param param = new GetQuestionnaireUseCase.Param(kitId,
+            questionnaireId,
+            currentUserId);
+
+        LoadQuestionnairePort.Result result = new LoadQuestionnairePort.Result(5,
+            List.of("team"),
+            "desc",
+            List.of(new LoadQuestionnairePort.Result.Question(1L, "title", 1, Boolean.TRUE)));
+
+        when(loadKitExpertGroupPort.loadKitExpertGroupId(kitId)).thenReturn(expertGroupId);
+        when(checkExpertGroupAccessPort.checkIsMember(expertGroupId, currentUserId)).thenReturn(true);
+        when(loadQuestionnairePort.loadQuestionnaire(questionnaireId, kitId)).thenReturn(result);
+
+        LoadQuestionnairePort.Result questionnaire = getQuestionnaireService.getQuestionnaire(param);
+
+        assertNotNull(questionnaire);
+    }
+
+    @Test
+    void testGetQuestionnaire_CurrentUserIsNotMemberOfExpertGroup_ThrowsException() {
+        Long kitId = 1L;
+        Long questionnaireId = 2L;
+        long expertGroupId = 3L;
+        UUID currentUserId = UUID.randomUUID();
+
+        GetQuestionnaireUseCase.Param param = new GetQuestionnaireUseCase.Param(kitId,
+            questionnaireId,
+            currentUserId);
+
+        when(loadKitExpertGroupPort.loadKitExpertGroupId(kitId)).thenReturn(expertGroupId);
+        when(checkExpertGroupAccessPort.checkIsMember(expertGroupId, currentUserId)).thenReturn(false);
+
+        assertThrows(AccessDeniedException.class, () -> getQuestionnaireService.getQuestionnaire(param));
+    }
+}

--- a/flickit-assessment-kit/src/test/resources/postman/flickit-assessment-kit.postman_collection.json
+++ b/flickit-assessment-kit/src/test/resources/postman/flickit-assessment-kit.postman_collection.json
@@ -278,6 +278,14 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "GetQuestionnaire",
+			"request": {
+				"method": "GET",
+				"header": []
+			},
+			"response": []
 		}
 	],
 	"event": [


### PR DESCRIPTION
To show questionnaire details of a kit in expert group page, this use case has implemented. Some unit tests corresponding to this use case have been added too. The GetQuestionnaire request has been added to a kit collection of Postman.